### PR TITLE
feat(e1): auth, workspaces, invites (closes #2)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,3 +9,6 @@ RESEND_API_KEY=
 # Sentry (leave blank to disable in dev)
 SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_DSN=
+
+# Public app URL — used for invite-accept links when the request has no Origin.
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "@supabase/supabase-js": "^2.47.10",
     "next": "15.1.3",
     "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react-dom": "19.0.0",
+    "resend": "^6.12.2",
+    "zod": "^4.4.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      resend:
+        specifier: ^6.12.2
+        version: 6.12.2
+      zod:
+        specifier: ^4.4.1
+        version: 4.4.1
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.5
@@ -1120,6 +1126,9 @@ packages:
     peerDependencies:
       webpack: '>=4.40.0'
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@supabase/auth-js@2.105.1':
     resolution: {integrity: sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==}
     engines: {node: '>=20.0.0'}
@@ -2062,6 +2071,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -2740,6 +2752,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -2866,6 +2881,15 @@ packages:
   require-in-the-middle@7.5.2:
     resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
     engines: {node: '>=8.6.0'}
+
+  resend@6.12.2:
+    resolution: {integrity: sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3016,6 +3040,9 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -3087,6 +3114,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.90.0:
+    resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3240,6 +3270,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -3414,6 +3449,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
 snapshots:
 
@@ -4444,6 +4482,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@stablelib/base64@1.0.1': {}
 
   '@supabase/auth-js@2.105.1':
     dependencies:
@@ -5623,6 +5663,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -6302,6 +6344,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-import@15.1.0(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
@@ -6419,6 +6463,11 @@ snapshots:
       resolve: 1.22.8
     transitivePeerDependencies:
       - supports-color
+
+  resend@6.12.2:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.90.0
 
   resolve-from@4.0.0: {}
 
@@ -6638,6 +6687,11 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -6727,6 +6781,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.90.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -6926,6 +6985,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid@10.0.0: {}
+
   uuid@9.0.1: {}
 
   vite-node@2.1.9(@types/node@22.19.17)(terser@5.46.2):
@@ -7119,3 +7180,5 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.1: {}

--- a/src/app/accept-invite/[token]/page.tsx
+++ b/src/app/accept-invite/[token]/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+export default function AcceptInvitePage() {
+  const router = useRouter();
+  const params = useParams<{ token: string }>();
+  const token = params?.token;
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!token) return;
+    setPending(true);
+    setError(null);
+    const res = await fetch(`/api/invites/${token}/accept`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ password }),
+    });
+    const data = await res.json().catch(() => ({}));
+    setPending(false);
+    if (!res.ok) {
+      setError(data.error ?? "Failed to accept invite");
+      return;
+    }
+    router.push(data.signedIn ? "/app" : "/login");
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-8">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm space-y-4 rounded-lg border border-slate-200 p-6"
+      >
+        <h1 className="text-xl font-semibold">Accept your invite</h1>
+        <p className="text-sm text-slate-600">
+          Set a password to join the workspace.
+        </p>
+        <label className="block text-sm">
+          <span className="block text-slate-700">Password</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={8}
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+          />
+        </label>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={pending}
+          className="w-full rounded-md bg-slate-900 px-3 py-2 text-sm text-white disabled:opacity-50"
+        >
+          {pending ? "Accepting…" : "Accept invite"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/service-role";
+import { rateLimit, clientIp } from "@/lib/rate-limit";
+
+const Body = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  workspaceName: z.string().min(1).max(100),
+});
+
+export async function POST(req: Request) {
+  const ip = clientIp(req);
+  const rl = rateLimit(`signup:${ip}`, { limit: 10, windowMs: 60_000 });
+  if (!rl.allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  let parsed;
+  try {
+    parsed = Body.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const { email, password, workspaceName } = parsed;
+
+  // Use the SSR client so the new session is written to the response cookies.
+  const supabase = await createSupabaseServerClient();
+  const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
+    email,
+    password,
+  });
+
+  if (signUpError || !signUpData.user) {
+    return NextResponse.json(
+      { error: signUpError?.message ?? "Signup failed" },
+      { status: 400 },
+    );
+  }
+
+  const userId = signUpData.user.id;
+
+  // Workspace + owner membership are created with the service-role client so
+  // we don't have to wait for/depend on email confirmation flows. RLS would
+  // otherwise block the very-first INSERT (chicken/egg: no membership yet).
+  const admin = createSupabaseServiceRoleClient();
+
+  const { data: workspace, error: wsError } = await admin
+    .from("workspaces")
+    .insert({ name: workspaceName })
+    .select("id, name")
+    .single();
+
+  if (wsError || !workspace) {
+    return NextResponse.json(
+      { error: wsError?.message ?? "Failed to create workspace" },
+      { status: 500 },
+    );
+  }
+
+  const { error: memError } = await admin.from("memberships").insert({
+    workspace_id: workspace.id,
+    user_id: userId,
+    role: "owner",
+    status: "active",
+  });
+
+  if (memError) {
+    return NextResponse.json({ error: memError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    workspace: { id: workspace.id, name: workspace.name },
+    user: { id: userId, email },
+  });
+}

--- a/src/app/api/invites/[token]/accept/route.ts
+++ b/src/app/api/invites/[token]/accept/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/service-role";
+import { hashInviteToken, isInviteExpired } from "@/lib/auth/tokens";
+import { rateLimit, clientIp } from "@/lib/rate-limit";
+
+const Body = z.object({
+  password: z.string().min(8),
+});
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const ip = clientIp(req);
+  const rl = rateLimit(`invite-accept:${ip}`, { limit: 10, windowMs: 60_000 });
+  if (!rl.allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const { token } = await params;
+  let parsed;
+  try {
+    parsed = Body.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const tokenHash = hashInviteToken(token);
+
+  // Service-role: invite acceptors are not yet authed for this workspace.
+  const admin = createSupabaseServiceRoleClient();
+
+  const { data: invite, error: inviteErr } = await admin
+    .from("invites")
+    .select("id, workspace_id, email, role, expires_at, accepted_at")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+
+  if (inviteErr || !invite) {
+    return NextResponse.json({ error: "Invalid invite" }, { status: 404 });
+  }
+  if (invite.accepted_at) {
+    return NextResponse.json(
+      { error: "Invite already accepted" },
+      { status: 410 },
+    );
+  }
+  if (isInviteExpired(invite.expires_at)) {
+    return NextResponse.json({ error: "Invite expired" }, { status: 410 });
+  }
+
+  // Find or create the auth user for this email.
+  let userId: string | undefined;
+  const { data: existingList } = await admin.auth.admin.listUsers();
+  const existing = existingList.users.find(
+    (u) => (u.email ?? "").toLowerCase() === invite.email.toLowerCase(),
+  );
+  if (existing) {
+    userId = existing.id;
+  } else {
+    const { data: created, error: createErr } =
+      await admin.auth.admin.createUser({
+        email: invite.email,
+        password: parsed.password,
+        email_confirm: true,
+      });
+    if (createErr || !created.user) {
+      return NextResponse.json(
+        { error: createErr?.message ?? "Failed to create user" },
+        { status: 500 },
+      );
+    }
+    userId = created.user.id;
+  }
+
+  // Upsert active membership.
+  const { error: memErr } = await admin.from("memberships").upsert(
+    {
+      workspace_id: invite.workspace_id,
+      user_id: userId,
+      role: invite.role,
+      status: "active",
+    },
+    { onConflict: "workspace_id,user_id" },
+  );
+  if (memErr) {
+    return NextResponse.json({ error: memErr.message }, { status: 500 });
+  }
+
+  const { error: acceptErr } = await admin
+    .from("invites")
+    .update({ accepted_at: new Date().toISOString() })
+    .eq("id", invite.id);
+  if (acceptErr) {
+    return NextResponse.json({ error: acceptErr.message }, { status: 500 });
+  }
+
+  // Sign the new (or existing) user in by setting an SSR session.
+  const supabase = await createSupabaseServerClient();
+  const { error: signInErr } = await supabase.auth.signInWithPassword({
+    email: invite.email,
+    password: parsed.password,
+  });
+  // Don't fail the whole request if sign-in fails (existing user may have a
+  // different password); the invite has already been accepted.
+  const signedIn = !signInErr;
+
+  return NextResponse.json({
+    workspaceId: invite.workspace_id,
+    role: invite.role,
+    signedIn,
+  });
+}

--- a/src/app/api/invites/route.ts
+++ b/src/app/api/invites/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/service-role";
+import { requireRole } from "@/lib/auth/guards";
+import { generateInviteToken, hashInviteToken } from "@/lib/auth/tokens";
+import { sendEmail, inviteEmail } from "@/lib/email/resend";
+
+const Body = z.object({
+  workspaceId: z.string().uuid(),
+  email: z.string().email(),
+  role: z.enum(["pm", "bookkeeper", "owner"]),
+});
+
+export async function POST(req: Request) {
+  let parsed;
+  try {
+    parsed = Body.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const { workspaceId, email, role } = parsed;
+
+  const guard = await requireRole(workspaceId, "owner");
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  const rawToken = generateInviteToken();
+  const tokenHash = hashInviteToken(rawToken);
+
+  // Owner has RLS access to insert; use the SSR client so policies apply.
+  const supabase = await createSupabaseServerClient();
+  const { data: invite, error } = await supabase
+    .from("invites")
+    .insert({
+      workspace_id: workspaceId,
+      email,
+      role,
+      token_hash: tokenHash,
+    })
+    .select("id, expires_at")
+    .single();
+
+  if (error || !invite) {
+    return NextResponse.json(
+      { error: error?.message ?? "Failed to create invite" },
+      { status: 500 },
+    );
+  }
+
+  // Look up workspace name for the email body. Use service-role to be safe
+  // even though the owner has SELECT access via RLS.
+  const admin = createSupabaseServiceRoleClient();
+  const { data: ws } = await admin
+    .from("workspaces")
+    .select("name")
+    .eq("id", workspaceId)
+    .single();
+
+  const origin =
+    req.headers.get("origin") ??
+    process.env.NEXT_PUBLIC_APP_URL ??
+    "http://localhost:3000";
+  const acceptUrl = `${origin}/accept-invite/${rawToken}`;
+
+  const { subject, html, text } = inviteEmail({
+    workspaceName: ws?.name ?? "your workspace",
+    acceptUrl,
+  });
+
+  await sendEmail({ to: email, subject, html, text });
+
+  return NextResponse.json({
+    invite: { id: invite.id, email, role, expiresAt: invite.expires_at },
+  });
+}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,0 +1,53 @@
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export default async function AppHome() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: memberships } = await supabase
+    .from("memberships")
+    .select("role, status, workspace:workspaces(id, name)")
+    .eq("user_id", user.id)
+    .eq("status", "active");
+
+  const rows = memberships ?? [];
+
+  return (
+    <main className="mx-auto max-w-2xl p-8">
+      <h1 className="text-2xl font-semibold">Your workspaces</h1>
+      <p className="mt-1 text-sm text-slate-500">Signed in as {user.email}</p>
+      <ul className="mt-6 space-y-3">
+        {rows.length === 0 && (
+          <li className="text-sm text-slate-600">No active memberships.</li>
+        )}
+        {rows.map((m) => {
+          const wsField = (
+            m as unknown as {
+              workspace:
+                | { id: string; name: string }
+                | { id: string; name: string }[]
+                | null;
+            }
+          ).workspace;
+          const ws = Array.isArray(wsField) ? wsField[0] : wsField;
+          if (!ws) return null;
+          return (
+            <li
+              key={ws.id}
+              className="flex items-center justify-between rounded-md border border-slate-200 p-4"
+            >
+              <span className="font-medium">{ws.name}</span>
+              <span className="text-xs uppercase tracking-wide text-slate-500">
+                {m.role}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </main>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createSupabaseBrowserClient } from "@/lib/supabase/browser";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+    const supabase = createSupabaseBrowserClient();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setPending(false);
+    if (error) {
+      setError(error.message);
+      return;
+    }
+    router.push("/app");
+    router.refresh();
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-8">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm space-y-4 rounded-lg border border-slate-200 p-6"
+      >
+        <h1 className="text-xl font-semibold">Log in</h1>
+        <label className="block text-sm">
+          <span className="block text-slate-700">Email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="block text-slate-700">Password</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+          />
+        </label>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={pending}
+          className="w-full rounded-md bg-slate-900 px-3 py-2 text-sm text-white disabled:opacity-50"
+        >
+          {pending ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function SignupPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [workspaceName, setWorkspaceName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+    const res = await fetch("/api/auth/signup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password, workspaceName }),
+    });
+    const data = await res.json().catch(() => ({}));
+    setPending(false);
+    if (!res.ok) {
+      setError(data.error ?? "Signup failed");
+      return;
+    }
+    router.push("/app");
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-8">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm space-y-4 rounded-lg border border-slate-200 p-6"
+      >
+        <h1 className="text-xl font-semibold">Create your workspace</h1>
+        <Field label="Workspace name" value={workspaceName} onChange={setWorkspaceName} />
+        <Field label="Email" type="email" value={email} onChange={setEmail} />
+        <Field label="Password" type="password" value={password} onChange={setPassword} />
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={pending}
+          className="w-full rounded-md bg-slate-900 px-3 py-2 text-sm text-white disabled:opacity-50"
+        >
+          {pending ? "Creating…" : "Sign up"}
+        </button>
+      </form>
+    </main>
+  );
+}
+
+function Field(props: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: string;
+}) {
+  return (
+    <label className="block text-sm">
+      <span className="block text-slate-700">{props.label}</span>
+      <input
+        type={props.type ?? "text"}
+        value={props.value}
+        onChange={(e) => props.onChange(e.target.value)}
+        required
+        className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+      />
+    </label>
+  );
+}

--- a/src/lib/auth/guards.ts
+++ b/src/lib/auth/guards.ts
@@ -1,0 +1,56 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export type Role = "owner" | "pm" | "bookkeeper";
+
+export type RoleCheckResult =
+  | { ok: true; userId: string; workspaceId: string; role: Role }
+  | { ok: false; status: 401 | 403; error: string };
+
+/**
+ * Verify the current authenticated user has at least the requested role
+ * within the given workspace. Designed to run inside a Route Handler
+ * (middleware can't easily read role from RLS).
+ */
+export async function requireRole(
+  workspaceId: string,
+  required: Role,
+): Promise<RoleCheckResult> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { ok: false, status: 401, error: "Not authenticated" };
+
+  const { data, error } = await supabase
+    .from("memberships")
+    .select("role, status")
+    .eq("workspace_id", workspaceId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error || !data || data.status !== "active") {
+    return { ok: false, status: 403, error: "Not a member of this workspace" };
+  }
+
+  if (!roleSatisfies(data.role as Role, required)) {
+    return { ok: false, status: 403, error: `Requires role: ${required}` };
+  }
+
+  return {
+    ok: true,
+    userId: user.id,
+    workspaceId,
+    role: data.role as Role,
+  };
+}
+
+const RANK: Record<Role, number> = { bookkeeper: 1, pm: 2, owner: 3 };
+
+/**
+ * Strictly: owner satisfies any required role; pm satisfies pm/bookkeeper;
+ * bookkeeper satisfies bookkeeper.
+ */
+export function roleSatisfies(actual: Role, required: Role): boolean {
+  return RANK[actual] >= RANK[required];
+}

--- a/src/lib/auth/tokens.ts
+++ b/src/lib/auth/tokens.ts
@@ -1,0 +1,25 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * Generate a URL-safe random invite token.
+ * Returns base64url so it can be embedded in a link without escaping.
+ */
+export function generateInviteToken(bytes = 32): string {
+  return randomBytes(bytes).toString("base64url");
+}
+
+/**
+ * Hash a raw invite token with sha256. Stored at rest; the raw token only
+ * lives in the email we send to the invitee.
+ */
+export function hashInviteToken(rawToken: string): string {
+  return createHash("sha256").update(rawToken).digest("hex");
+}
+
+/**
+ * True when the given expires_at is strictly in the future.
+ */
+export function isInviteExpired(expiresAt: string | Date, now: Date = new Date()): boolean {
+  const exp = typeof expiresAt === "string" ? new Date(expiresAt) : expiresAt;
+  return exp.getTime() <= now.getTime();
+}

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,0 +1,67 @@
+import { Resend } from "resend";
+
+export interface SendEmailArgs {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+  from?: string;
+}
+
+const DEFAULT_FROM = "purchaseer <onboarding@purchaseer.app>";
+
+/**
+ * Thin Resend wrapper. If `RESEND_API_KEY` is unset, logs the payload to
+ * console so dev/test flows work without a real key.
+ */
+export async function sendEmail(args: SendEmailArgs): Promise<{ id: string | null }> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = args.from ?? DEFAULT_FROM;
+
+  if (!apiKey) {
+    console.info("[email:dev]", {
+      to: args.to,
+      from,
+      subject: args.subject,
+      text: args.text,
+      html: args.html,
+    });
+    return { id: null };
+  }
+
+  const resend = new Resend(apiKey);
+  const result = await resend.emails.send({
+    to: args.to,
+    from,
+    subject: args.subject,
+    html: args.html,
+    text: args.text,
+  });
+
+  if (result.error) {
+    throw new Error(`Resend send failed: ${result.error.message}`);
+  }
+  return { id: result.data?.id ?? null };
+}
+
+export function inviteEmail(opts: {
+  workspaceName: string;
+  acceptUrl: string;
+}): { subject: string; html: string; text: string } {
+  const subject = `You're invited to ${opts.workspaceName} on purchaseer`;
+  const text = `You've been invited to join ${opts.workspaceName} on purchaseer.\n\nAccept your invite:\n${opts.acceptUrl}\n\nThis link expires in 7 days.`;
+  const html = `<p>You've been invited to join <strong>${escapeHtml(opts.workspaceName)}</strong> on purchaseer.</p>
+<p><a href="${opts.acceptUrl}">Accept your invite</a></p>
+<p style="color:#666;font-size:12px">Or copy this link: ${opts.acceptUrl}</p>
+<p style="color:#666;font-size:12px">This link expires in 7 days.</p>`;
+  return { subject, html, text };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,50 @@
+/**
+ * Tiny in-memory token-bucket rate limiter keyed by IP (or arbitrary key).
+ * Acceptable for sprint-01 single-instance dev. For production this should
+ * be swapped for Upstash Ratelimit (or similar) so limits are shared across
+ * serverless instances.
+ */
+
+type Bucket = { tokens: number; updatedAt: number };
+
+const buckets = new Map<string, Bucket>();
+
+export interface RateLimitOptions {
+  /** Number of allowed requests per window. */
+  limit: number;
+  /** Window in milliseconds. */
+  windowMs: number;
+}
+
+export function rateLimit(
+  key: string,
+  { limit, windowMs }: RateLimitOptions,
+): { allowed: boolean; remaining: number } {
+  const now = Date.now();
+  const refillRate = limit / windowMs; // tokens per ms
+  const existing = buckets.get(key);
+
+  if (!existing) {
+    buckets.set(key, { tokens: limit - 1, updatedAt: now });
+    return { allowed: true, remaining: limit - 1 };
+  }
+
+  const elapsed = now - existing.updatedAt;
+  const tokens = Math.min(limit, existing.tokens + elapsed * refillRate);
+
+  if (tokens < 1) {
+    existing.tokens = tokens;
+    existing.updatedAt = now;
+    return { allowed: false, remaining: 0 };
+  }
+
+  existing.tokens = tokens - 1;
+  existing.updatedAt = now;
+  return { allowed: true, remaining: Math.floor(existing.tokens) };
+}
+
+export function clientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0]!.trim();
+  return req.headers.get("x-real-ip") ?? "unknown";
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,86 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+
+/**
+ * Public paths that DO NOT require authentication.
+ * - /api/auth/signup: creates the very first user.
+ * - /api/invites/:token/accept: token-gated, used by un-authed invitees.
+ * - /accept-invite/[token]: the static page invitees land on.
+ * - /signup, /login: auth pages.
+ */
+const PUBLIC_PATHS = ["/", "/signup", "/login", "/api/auth/signup"];
+
+function isPublic(pathname: string): boolean {
+  if (PUBLIC_PATHS.includes(pathname)) return true;
+  if (pathname.startsWith("/accept-invite/")) return true;
+  if (pathname.startsWith("/api/invites/") && pathname.endsWith("/accept")) {
+    return true;
+  }
+  // Next.js / static assets
+  if (
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/favicon") ||
+    pathname.startsWith("/static")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next({ request: req });
+
+  // No env vars → can't do auth; let through (dev/scaffold safety).
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  ) {
+    return res;
+  }
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() {
+          return req.cookies.getAll();
+        },
+        setAll(cookiesToSet: { name: string; value: string; options: CookieOptions }[]) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            res.cookies.set({ name, value, ...options });
+          });
+        },
+      },
+    },
+  );
+
+  // Refresh the session cookie on every request.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { pathname } = req.nextUrl;
+
+  if (isPublic(pathname)) return res;
+
+  // Gate /api/* and authenticated app routes.
+  const requiresAuth =
+    pathname.startsWith("/api/") || pathname.startsWith("/app");
+
+  if (requiresAuth && !user) {
+    if (pathname.startsWith("/api/")) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const url = req.nextUrl.clone();
+    url.pathname = "/login";
+    url.searchParams.set("next", pathname);
+    return NextResponse.redirect(url);
+  }
+
+  return res;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/supabase/migrations/20260430193303_e1_auth_workspaces_invites.sql
+++ b/supabase/migrations/20260430193303_e1_auth_workspaces_invites.sql
@@ -1,0 +1,136 @@
+-- E1: Auth + Workspaces + Invites
+-- Tables: workspaces, memberships, invites
+-- RLS keyed on workspace_id via auth.user_workspace_ids() helper.
+
+create extension if not exists "citext";
+create extension if not exists "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- Enums
+-- ---------------------------------------------------------------------------
+do $$ begin
+  create type membership_role as enum ('owner', 'pm', 'bookkeeper');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type membership_status as enum ('active', 'invited', 'revoked');
+exception when duplicate_object then null; end $$;
+
+-- ---------------------------------------------------------------------------
+-- Tables
+-- ---------------------------------------------------------------------------
+create table if not exists public.workspaces (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.memberships (
+  workspace_id uuid not null references public.workspaces(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role membership_role not null,
+  status membership_status not null default 'active',
+  created_at timestamptz not null default now(),
+  primary key (workspace_id, user_id)
+);
+
+create index if not exists memberships_user_idx on public.memberships(user_id);
+
+create table if not exists public.invites (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references public.workspaces(id) on delete cascade,
+  email citext not null,
+  role membership_role not null,
+  token_hash text not null unique,
+  expires_at timestamptz not null default (now() + interval '7 days'),
+  accepted_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists invites_workspace_idx on public.invites(workspace_id);
+
+-- ---------------------------------------------------------------------------
+-- Helper: current user's active workspace ids
+-- ---------------------------------------------------------------------------
+create or replace function auth.user_workspace_ids()
+returns setof uuid
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select workspace_id
+  from public.memberships
+  where user_id = auth.uid()
+    and status = 'active';
+$$;
+
+grant execute on function auth.user_workspace_ids() to authenticated, anon;
+
+-- ---------------------------------------------------------------------------
+-- RLS
+-- ---------------------------------------------------------------------------
+alter table public.workspaces enable row level security;
+alter table public.memberships enable row level security;
+alter table public.invites enable row level security;
+
+-- workspaces: members can SELECT their workspace.
+drop policy if exists "workspaces_select_members" on public.workspaces;
+create policy "workspaces_select_members" on public.workspaces
+  for select using (id in (select auth.user_workspace_ids()));
+
+-- memberships: members can SELECT memberships of their workspace.
+drop policy if exists "memberships_select_same_ws" on public.memberships;
+create policy "memberships_select_same_ws" on public.memberships
+  for select using (workspace_id in (select auth.user_workspace_ids()));
+
+-- memberships: only owners can INSERT.
+drop policy if exists "memberships_insert_owner" on public.memberships;
+create policy "memberships_insert_owner" on public.memberships
+  for insert with check (
+    exists (
+      select 1 from public.memberships m
+      where m.workspace_id = memberships.workspace_id
+        and m.user_id = auth.uid()
+        and m.role = 'owner'
+        and m.status = 'active'
+    )
+  );
+
+-- memberships: only owners can UPDATE.
+drop policy if exists "memberships_update_owner" on public.memberships;
+create policy "memberships_update_owner" on public.memberships
+  for update using (
+    exists (
+      select 1 from public.memberships m
+      where m.workspace_id = memberships.workspace_id
+        and m.user_id = auth.uid()
+        and m.role = 'owner'
+        and m.status = 'active'
+    )
+  );
+
+-- invites: only owners can SELECT/INSERT for their workspace.
+drop policy if exists "invites_select_owner" on public.invites;
+create policy "invites_select_owner" on public.invites
+  for select using (
+    exists (
+      select 1 from public.memberships m
+      where m.workspace_id = invites.workspace_id
+        and m.user_id = auth.uid()
+        and m.role = 'owner'
+        and m.status = 'active'
+    )
+  );
+
+drop policy if exists "invites_insert_owner" on public.invites;
+create policy "invites_insert_owner" on public.invites
+  for insert with check (
+    exists (
+      select 1 from public.memberships m
+      where m.workspace_id = invites.workspace_id
+        and m.user_id = auth.uid()
+        and m.role = 'owner'
+        and m.status = 'active'
+    )
+  );

--- a/tests/integration/invite-flow.test.ts
+++ b/tests/integration/invite-flow.test.ts
@@ -1,0 +1,10 @@
+import { describe, it } from "vitest";
+
+// TODO(issue-2): wire up `supabase start` integration tests for the full
+// signup → invite → accept flow. Skipping until Docker/local Supabase is
+// reliably available in this environment.
+describe.skip("invite flow (integration)", () => {
+  it("signup -> invite -> accept", () => {
+    // placeholder
+  });
+});

--- a/tests/unit/guards.test.ts
+++ b/tests/unit/guards.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { roleSatisfies } from "@/lib/auth/guards";
+
+describe("roleSatisfies", () => {
+  it("owner satisfies any role", () => {
+    expect(roleSatisfies("owner", "owner")).toBe(true);
+    expect(roleSatisfies("owner", "pm")).toBe(true);
+    expect(roleSatisfies("owner", "bookkeeper")).toBe(true);
+  });
+
+  it("pm satisfies pm and bookkeeper but not owner", () => {
+    expect(roleSatisfies("pm", "owner")).toBe(false);
+    expect(roleSatisfies("pm", "pm")).toBe(true);
+    expect(roleSatisfies("pm", "bookkeeper")).toBe(true);
+  });
+
+  it("bookkeeper only satisfies bookkeeper", () => {
+    expect(roleSatisfies("bookkeeper", "owner")).toBe(false);
+    expect(roleSatisfies("bookkeeper", "pm")).toBe(false);
+    expect(roleSatisfies("bookkeeper", "bookkeeper")).toBe(true);
+  });
+});

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { rateLimit } from "@/lib/rate-limit";
+
+describe("rateLimit", () => {
+  it("allows up to limit then blocks", () => {
+    const key = `test:${Math.random()}`;
+    for (let i = 0; i < 5; i++) {
+      expect(rateLimit(key, { limit: 5, windowMs: 60_000 }).allowed).toBe(true);
+    }
+    expect(rateLimit(key, { limit: 5, windowMs: 60_000 }).allowed).toBe(false);
+  });
+});

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateInviteToken,
+  hashInviteToken,
+  isInviteExpired,
+} from "@/lib/auth/tokens";
+
+describe("invite tokens", () => {
+  it("generates URL-safe random tokens of decent length", () => {
+    const t = generateInviteToken();
+    expect(t).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(t.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it("hashInviteToken is deterministic sha256 hex", () => {
+    const h1 = hashInviteToken("hello");
+    const h2 = hashInviteToken("hello");
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashInviteToken("hello1")).not.toBe(h1);
+  });
+
+  it("isInviteExpired works with past and future dates", () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    expect(isInviteExpired(past)).toBe(true);
+    expect(isInviteExpired(future)).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    include: ["src/**/*.{test,spec}.{ts,tsx}", "tests/unit/**/*.{test,spec}.{ts,tsx}"],
+    include: [
+      "src/**/*.{test,spec}.{ts,tsx}",
+      "tests/unit/**/*.{test,spec}.{ts,tsx}",
+      "tests/integration/**/*.{test,spec}.{ts,tsx}",
+    ],
     exclude: ["tests/e2e/**", "node_modules/**", ".next/**"],
   },
   resolve: {


### PR DESCRIPTION
## Summary
Implements E1 of sprint-01: workspace + auth + invites.

### Schema (`supabase/migrations/20260430193303_e1_auth_workspaces_invites.sql`)
- `workspaces (id, name, created_at)`
- `memberships (workspace_id, user_id, role, status, created_at)` — PK `(workspace_id, user_id)`; enums `membership_role` (owner|pm|bookkeeper) and `membership_status` (active|invited|revoked).
- `invites (id, workspace_id, email citext, role, token_hash unique, expires_at default now()+7d, accepted_at, created_at)`.
- `citext` + `pgcrypto` extensions enabled. `gen_random_uuid()` for ids.

### Routes (App Router under `src/app/api/`)
- `POST /api/auth/signup` — public; signs up via Supabase Auth, then service-role inserts workspace + owner membership (sidesteps the chicken/egg with RLS).
- `POST /api/invites` — owner-gated via `requireRole`; raw token generated server-side, only `sha256(token)` is persisted; raw token mailed via Resend.
- `POST /api/invites/:token/accept` — public, token-gated; service-role creates the auth user (or finds existing), upserts an active membership, marks invite accepted, attempts to sign the new user in.

### RLS approach
- Helper `auth.user_workspace_ids()` (SECURITY DEFINER, stable) returns the active workspace ids for `auth.uid()`.
- `workspaces` SELECT: members of that workspace.
- `memberships` SELECT: same workspace; INSERT/UPDATE: only active owners (subquery on `memberships`, not the helper, to gate by role).
- `invites` SELECT/INSERT: only active owners. Accept flow uses service-role since the invitee is not yet a member.

### Auth wiring
- `src/middleware.ts` refreshes the Supabase SSR session on every request and redirects unauthenticated `/app` traffic to `/login` (and 401s `/api/*`). Public exceptions: `/signup`, `/login`, `/api/auth/signup`, `/accept-invite/[token]`, `/api/invites/[token]/accept`.
- Role checks live in handlers via `requireRole(workspaceId, role)` (`src/lib/auth/guards.ts`) — middleware can't easily read role data.

### Email (Resend)
- `src/lib/email/resend.ts`: real send when `RESEND_API_KEY` is set, otherwise `console.info('[email:dev]', ...)` so local dev works without a key.
- Subject: `You're invited to {workspaceName} on purchaseer`. Body links to `${origin}/accept-invite/${rawToken}`.

### UI
- `/signup`, `/login`, `/accept-invite/[token]`, `/app` — minimal forms enough to verify the full flow end-to-end (signup -> invite -> accept -> see workspace + role).

### Tests
- Vitest unit: token hashing/expiry (`tokens.test.ts`), `roleSatisfies` hierarchy (`guards.test.ts`), rate-limit allow/block (`rate-limit.test.ts`).
- Integration test scaffold under `tests/integration/invite-flow.test.ts` is `describe.skip`'d with a TODO — Docker-backed `supabase start` not exercised in this env.

## Limitations / follow-ups
- Rate limit is a process-local in-memory token bucket (10/min on signup + accept). Acceptable for sprint-01 single-instance dev; production should swap for Upstash Ratelimit so limits are shared across serverless instances. Marked with a comment in `src/lib/rate-limit.ts`.
- No automated migration apply: `supabase db push` is left to whoever wires up the project credentials.
- Owner role-check in handlers duplicates the RLS predicate. Acceptable given owner-only routes; revisit if more fine-grained roles arrive.

## Test plan
- [ ] `pnpm lint` clean
- [ ] `pnpm test` 8 passed / 1 skipped
- [ ] `pnpm build` succeeds
- [ ] With Supabase project + migration applied: signup creates workspace + owner; owner invite mails a link; invitee can accept and lands at `/app` showing workspace + role.

Closes #2.