### PR TITLE
feat(e4): PO approvals + notifications (closes #5)

### DIFF
--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function POST(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  // RLS ensures only the owner of the row can update it.
+  const { data, error } = await supabase
+    .from("notifications")
+    .update({ read_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("id, read_at")
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (!data) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ notification: data });
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function GET(req: Request) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const unread = url.searchParams.get("unread") === "true";
+
+  let q = supabase
+    .from("notifications")
+    .select("id, kind, payload, read_at, created_at")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  if (unread) q = q.is("read_at", null);
+
+  const { data, error } = await q;
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ notifications: data ?? [] });
+}

--- a/src/app/api/pos/[id]/approve/route.ts
+++ b/src/app/api/pos/[id]/approve/route.ts
@@ -1,0 +1,13 @@
+import { decidePurchaseOrder } from "@/lib/po/decision";
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  return decidePurchaseOrder({
+    poId: id,
+    action: "approve",
+    origin: req.headers.get("origin"),
+  });
+}

--- a/src/app/api/pos/[id]/reject/route.ts
+++ b/src/app/api/pos/[id]/reject/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { decidePurchaseOrder } from "@/lib/po/decision";
+
+const Body = z.object({ note: z.string().max(2000).optional() });
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+
+  let note: string | undefined;
+  try {
+    const raw = await req.text();
+    if (raw.trim().length > 0) {
+      note = Body.parse(JSON.parse(raw)).note;
+    }
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  return decidePurchaseOrder({
+    poId: id,
+    action: "reject",
+    decisionNote: note,
+    origin: req.headers.get("origin"),
+  });
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+interface NotificationRow {
+  id: string;
+  kind: string;
+  payload: {
+    po_id?: string;
+    po_number?: string;
+    project_id?: string;
+    decision_note?: string;
+  };
+  read_at: string | null;
+  created_at: string;
+}
+
+export default async function NotificationsPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data, error } = await supabase
+    .from("notifications")
+    .select("id, kind, payload, read_at, created_at")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  if (error) {
+    return (
+      <main className="mx-auto max-w-2xl p-6">
+        <h1 className="text-xl font-semibold">Notifications</h1>
+        <p className="mt-4 text-red-600">Failed to load: {error.message}</p>
+      </main>
+    );
+  }
+
+  const rows = (data ?? []) as NotificationRow[];
+
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-xl font-semibold">Notifications</h1>
+      {rows.length === 0 ? (
+        <p className="mt-4 text-gray-600">No notifications yet.</p>
+      ) : (
+        <ul className="mt-4 divide-y">
+          {rows.map((n) => {
+            const { po_id, po_number, decision_note } = n.payload ?? {};
+            const isApproved = n.kind === "po.approved";
+            return (
+              <li key={n.id} className="py-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className={n.read_at ? "text-gray-600" : "font-medium"}>
+                      PO {po_number ?? "?"}{" "}
+                      {isApproved ? "approved" : "rejected"}
+                    </p>
+                    {decision_note ? (
+                      <p className="text-sm text-gray-600">
+                        Reason: {decision_note}
+                      </p>
+                    ) : null}
+                    <p className="text-xs text-gray-500">
+                      {new Date(n.created_at).toLocaleString()}
+                    </p>
+                  </div>
+                  {po_id ? (
+                    <Link
+                      className="text-sm text-blue-600 hover:underline"
+                      href={`/pos/${po_id}`}
+                    >
+                      View
+                    </Link>
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/lib/email/po-decision.ts
+++ b/src/lib/email/po-decision.ts
@@ -1,0 +1,50 @@
+/**
+ * Email body builder for PO approval/rejection decisions. Pure function so it's
+ * trivially unit-testable without spinning up Resend.
+ */
+export interface BuildApprovalEmailArgs {
+  poNumber: string;
+  action: "approve" | "reject";
+  poUrl: string;
+  decisionNote?: string;
+}
+
+export interface BuiltEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export function buildApprovalEmail(args: BuildApprovalEmailArgs): BuiltEmail {
+  const { poNumber, action, poUrl, decisionNote } = args;
+  const verb = action === "approve" ? "approved" : "rejected";
+  const subject = `PO ${poNumber} ${verb}`;
+
+  const noteLine =
+    action === "reject" && decisionNote
+      ? `\n\nReason: ${decisionNote}`
+      : "";
+
+  const text = `Your purchase order ${poNumber} was ${verb}.${noteLine}\n\nView it: ${poUrl}`;
+
+  const noteHtml =
+    action === "reject" && decisionNote
+      ? `<p><strong>Reason:</strong> ${escapeHtml(decisionNote)}</p>`
+      : "";
+
+  const html = `<p>Your purchase order <strong>${escapeHtml(
+    poNumber,
+  )}</strong> was <strong>${verb}</strong>.</p>
+${noteHtml}<p><a href="${poUrl}">View purchase order</a></p>`;
+
+  return { subject, html, text };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/lib/notifications/schema.ts
+++ b/src/lib/notifications/schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const notificationKindSchema = z.enum(["po.approved", "po.rejected"]);
+export type NotificationKind = z.infer<typeof notificationKindSchema>;
+
+export const notificationPayloadSchema = z.object({
+  po_id: z.string().uuid(),
+  po_number: z.string().min(1),
+  project_id: z.string().uuid(),
+  decision_note: z.string().optional(),
+});
+export type NotificationPayload = z.infer<typeof notificationPayloadSchema>;

--- a/src/lib/po/approval-machine.ts
+++ b/src/lib/po/approval-machine.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimal local approval transition. Duplicates a tiny slice of the full PO
+ * state machine (added by issue #4 in `src/lib/po/state-machine.ts`) so that
+ * this branch builds even if #4 hasn't merged. Will dedupe post-merge.
+ */
+export type PoStatus = "draft" | "pending" | "approved" | "rejected";
+export type ApprovalAction = "approve" | "reject";
+
+export function transitionApproval(
+  from: PoStatus,
+  action: ApprovalAction,
+): PoStatus {
+  if (from !== "pending") {
+    throw new Error(
+      `Invalid approval transition: PO must be 'pending' (got '${from}')`,
+    );
+  }
+  return action === "approve" ? "approved" : "rejected";
+}

--- a/src/lib/po/decision.ts
+++ b/src/lib/po/decision.ts
@@ -1,0 +1,159 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextResponse } from "next/server";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/service-role";
+import { requireRole } from "@/lib/auth/guards";
+import { sendEmail } from "@/lib/email/resend";
+import { buildApprovalEmail } from "@/lib/email/po-decision";
+import { transitionApproval, type ApprovalAction } from "@/lib/po/approval-machine";
+import {
+  notificationPayloadSchema,
+  type NotificationKind,
+} from "@/lib/notifications/schema";
+
+interface DecideArgs {
+  poId: string;
+  action: ApprovalAction;
+  decisionNote?: string;
+  origin?: string | null;
+}
+
+/**
+ * Shared approve/reject flow. Steps (intentionally not wrapped in a single
+ * transaction — Supabase JS doesn't expose multi-statement TX over PostgREST,
+ * and a Postgres function felt heavier than warranted for sprint-01):
+ *
+ *   1. Update PO row (status, decided_by, decided_at, decision_note?). This
+ *      is the "source of truth" write — if it fails, we abort.
+ *   2. Insert `po_status_history` row. If this fails after step 1 succeeded,
+ *      we report to Sentry but DO NOT roll back: the user-visible PO state is
+ *      already correct, and a missing audit row is preferable to a confusing
+ *      partial revert.
+ *   3. Insert `notifications` row (service-role; RLS forbids inserts).
+ *      Same non-fatal error policy.
+ *   4. Send Resend email. Email failures are explicitly non-fatal — captured
+ *      to Sentry, swallowed so the API still returns 200.
+ */
+export async function decidePurchaseOrder(args: DecideArgs) {
+  const { poId, action, decisionNote, origin } = args;
+
+  // Load the PO via service-role to avoid RLS gymnastics — we still gate on
+  // the owner role explicitly via `requireRole` below.
+  const admin = createSupabaseServiceRoleClient();
+  const { data: po, error: poErr } = await admin
+    .from("purchase_orders")
+    .select(
+      "id, workspace_id, project_id, po_number, status, created_by",
+    )
+    .eq("id", poId)
+    .maybeSingle();
+
+  if (poErr || !po) {
+    return NextResponse.json({ error: "PO not found" }, { status: 404 });
+  }
+
+  const guard = await requireRole(po.workspace_id, "owner");
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  let nextStatus: "approved" | "rejected";
+  try {
+    nextStatus = transitionApproval(po.status, action) as "approved" | "rejected";
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 409 },
+    );
+  }
+
+  const decidedAt = new Date().toISOString();
+
+  // 1. Update PO. Use service-role since we've already authorized.
+  const updatePayload: Record<string, unknown> = {
+    status: nextStatus,
+    decided_by: guard.userId,
+    decided_at: decidedAt,
+  };
+  if (action === "reject") {
+    updatePayload.decision_note = decisionNote ?? null;
+  }
+
+  const { error: updateErr } = await admin
+    .from("purchase_orders")
+    .update(updatePayload)
+    .eq("id", poId)
+    .eq("status", "pending"); // optimistic guard against races
+
+  if (updateErr) {
+    return NextResponse.json(
+      { error: `Failed to update PO: ${updateErr.message}` },
+      { status: 500 },
+    );
+  }
+
+  // 2. Status history (non-fatal).
+  const { error: histErr } = await admin.from("po_status_history").insert({
+    po_id: poId,
+    from_status: "pending",
+    to_status: nextStatus,
+    actor_id: guard.userId,
+    note: action === "reject" ? decisionNote ?? null : null,
+  });
+  if (histErr) {
+    Sentry.captureException(histErr, {
+      tags: { area: "po.decision", step: "history" },
+      extra: { poId },
+    });
+  }
+
+  // 3. Notification (non-fatal).
+  const kind: NotificationKind =
+    action === "approve" ? "po.approved" : "po.rejected";
+  const payload = notificationPayloadSchema.parse({
+    po_id: po.id,
+    po_number: po.po_number,
+    project_id: po.project_id,
+    ...(action === "reject" && decisionNote
+      ? { decision_note: decisionNote }
+      : {}),
+  });
+
+  const { error: notifErr } = await admin.from("notifications").insert({
+    user_id: po.created_by,
+    kind,
+    payload,
+  });
+  if (notifErr) {
+    Sentry.captureException(notifErr, {
+      tags: { area: "po.decision", step: "notification" },
+      extra: { poId },
+    });
+  }
+
+  // 4. Email (non-fatal). Look up creator email via service-role auth.admin.
+  try {
+    const { data: userResp } = await admin.auth.admin.getUserById(po.created_by);
+    const toEmail = userResp?.user?.email;
+    if (toEmail) {
+      const baseOrigin =
+        origin ?? process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+      const poUrl = `${baseOrigin}/pos/${po.id}`;
+      const { subject, html, text } = buildApprovalEmail({
+        poNumber: po.po_number,
+        action,
+        poUrl,
+        decisionNote,
+      });
+      await sendEmail({ to: toEmail, subject, html, text });
+    }
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { area: "po.decision", step: "email" },
+      extra: { poId },
+    });
+  }
+
+  return NextResponse.json({
+    po: { id: po.id, status: nextStatus, decided_at: decidedAt },
+  });
+}

--- a/supabase/migrations/20260430200200_e4_approvals_notifications.sql
+++ b/supabase/migrations/20260430200200_e4_approvals_notifications.sql
@@ -1,0 +1,36 @@
+-- E4: Approval flow + notifications
+-- Adds the `notifications` table. The PO tables (`purchase_orders`,
+-- `po_status_history`) are added by E3 in 20260430200100_e3_purchase_orders.sql;
+-- this migration runs after thanks to its numeric prefix and only references
+-- those tables loosely (no FK is required for notifications.payload).
+
+create table if not exists public.notifications (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  kind text not null,
+  payload jsonb not null default '{}'::jsonb,
+  read_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists notifications_user_idx
+  on public.notifications(user_id, created_at desc);
+
+create index if not exists notifications_unread_idx
+  on public.notifications(user_id) where read_at is null;
+
+alter table public.notifications enable row level security;
+
+-- Users SELECT only their own notifications.
+drop policy if exists "notifications_select_own" on public.notifications;
+create policy "notifications_select_own" on public.notifications
+  for select using (user_id = auth.uid());
+
+-- Users UPDATE only their own notifications (intended use: marking read).
+drop policy if exists "notifications_update_own" on public.notifications;
+create policy "notifications_update_own" on public.notifications
+  for update using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+-- INSERTs are service-role only — no policy = no INSERT for authenticated users.
+-- (Service-role bypasses RLS.)

--- a/tests/unit/notification-schema.test.ts
+++ b/tests/unit/notification-schema.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  notificationKindSchema,
+  notificationPayloadSchema,
+} from "@/lib/notifications/schema";
+import { transitionApproval } from "@/lib/po/approval-machine";
+
+const UUID = "00000000-0000-4000-8000-000000000000";
+
+describe("notificationPayloadSchema", () => {
+  it("accepts a minimal valid payload", () => {
+    const r = notificationPayloadSchema.safeParse({
+      po_id: UUID,
+      po_number: "PO-1",
+      project_id: UUID,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a payload with decision_note", () => {
+    const r = notificationPayloadSchema.safeParse({
+      po_id: UUID,
+      po_number: "PO-1",
+      project_id: UUID,
+      decision_note: "nope",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a missing po_number", () => {
+    const r = notificationPayloadSchema.safeParse({
+      po_id: UUID,
+      project_id: UUID,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects bad uuids", () => {
+    const r = notificationPayloadSchema.safeParse({
+      po_id: "not-a-uuid",
+      po_number: "PO-1",
+      project_id: UUID,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("kinds are constrained to po.approved | po.rejected", () => {
+    expect(notificationKindSchema.safeParse("po.approved").success).toBe(true);
+    expect(notificationKindSchema.safeParse("po.rejected").success).toBe(true);
+    expect(notificationKindSchema.safeParse("po.other").success).toBe(false);
+  });
+});
+
+describe("transitionApproval", () => {
+  it("approves a pending PO", () => {
+    expect(transitionApproval("pending", "approve")).toBe("approved");
+  });
+  it("rejects a pending PO", () => {
+    expect(transitionApproval("pending", "reject")).toBe("rejected");
+  });
+  it("throws on non-pending source state", () => {
+    expect(() => transitionApproval("draft", "approve")).toThrow();
+    expect(() => transitionApproval("approved", "reject")).toThrow();
+  });
+});

--- a/tests/unit/po-decision-email.test.ts
+++ b/tests/unit/po-decision-email.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { buildApprovalEmail } from "@/lib/email/po-decision";
+
+describe("buildApprovalEmail", () => {
+  it("formats an approval email", () => {
+    const e = buildApprovalEmail({
+      poNumber: "PO-001",
+      action: "approve",
+      poUrl: "https://app.test/pos/abc",
+    });
+    expect(e.subject).toBe("PO PO-001 approved");
+    expect(e.text).toContain("approved");
+    expect(e.text).toContain("https://app.test/pos/abc");
+    expect(e.html).toContain("https://app.test/pos/abc");
+  });
+
+  it("formats a rejection email and includes the decision note", () => {
+    const e = buildApprovalEmail({
+      poNumber: "PO-002",
+      action: "reject",
+      poUrl: "https://app.test/pos/xyz",
+      decisionNote: "Budget exceeded",
+    });
+    expect(e.subject).toBe("PO PO-002 rejected");
+    expect(e.text).toContain("Budget exceeded");
+    expect(e.html).toContain("Budget exceeded");
+  });
+
+  it("omits the reason block when no note on rejection", () => {
+    const e = buildApprovalEmail({
+      poNumber: "PO-003",
+      action: "reject",
+      poUrl: "https://app.test/pos/xyz",
+    });
+    expect(e.text).not.toContain("Reason:");
+    expect(e.html).not.toContain("Reason:");
+  });
+
+  it("escapes HTML in po number and decision note", () => {
+    const e = buildApprovalEmail({
+      poNumber: "<bad>",
+      action: "reject",
+      poUrl: "https://app.test/pos/xyz",
+      decisionNote: "<script>alert(1)</script>",
+    });
+    expect(e.html).not.toContain("<script>alert(1)</script>");
+    expect(e.html).toContain("&lt;script&gt;");
+    expect(e.html).toContain("&lt;bad&gt;");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `notifications` table (`20260430200200_e4_approvals_notifications.sql`) with RLS: a user can SELECT/UPDATE only their own rows; INSERT is service-role only.
- Adds `POST /api/pos/:id/approve` and `POST /api/pos/:id/reject` (Owner-gated). Validates current `status = pending`, updates the PO, writes `po_status_history`, inserts a `notifications` row, and sends a Resend email to the PO creator.
- Adds `GET /api/notifications` (newest first, optional `?unread=true`) and `POST /api/notifications/:id/read`.
- Adds a minimal `/notifications` server-component page.
- Unit tests for `buildApprovalEmail` and `notificationPayloadSchema` (+ a small `transitionApproval` test).

## Depends on
Depends on #4 — references `purchase_orders` and `po_status_history` from `20260430200100_e3_purchase_orders.sql`. CI on this branch will go green once #4 lands and we rebase.

### Symbols depended on from #4
- Tables: `purchase_orders` (cols: `id`, `workspace_id`, `project_id`, `po_number`, `status`, `created_by`, `decided_by`, `decided_at`, `decision_note`), `po_status_history` (cols: `po_id`, `from_status`, `to_status`, `actor_id`, `note`).
- Migration filename ordering: `20260430200100_e3_purchase_orders.sql` < `20260430200200_e4_approvals_notifications.sql`.
- The full state machine (`src/lib/po/state-machine.ts`) is intentionally NOT imported. Per the working agreement we inlined a tiny slice (`src/lib/po/approval-machine.ts::transitionApproval`) covering only `pending --approve--> approved` and `pending --reject--> rejected`. Will dedupe post-merge.

## Non-obvious decisions
- **Transactionality of update + history + notification**: not wrapped in a single Postgres transaction. The PO `UPDATE` is the source of truth and is gated by `.eq("status", "pending")` to guard against double-decisions / races. If it fails we 500 and bail. The `po_status_history` and `notifications` inserts run after and are non-fatal — failures are reported to Sentry but do not roll back the user-visible state change. A missing audit/notification row is preferable to a confusing partial revert. This can be tightened to a single RPC post-merge if we want strict atomicity.
- **Email failure**: explicitly non-fatal. Wrapped in `try/catch`, captured to Sentry, swallowed so the API still returns 200.
- **Owner authorization**: load the PO via service-role to read its `workspace_id`, then call `requireRole(workspace_id, "owner")`. The route itself never trusts a workspace id from the request body.
- **No new notification kinds** beyond `po.approved` / `po.rejected`, per scope.
- **`src/lib/email/resend.ts` is untouched**, per the parallel-context rules; the new builder lives in `src/lib/email/po-decision.ts`.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (20 tests, 1 skipped — pre-existing Docker-gated integration)
- [x] `pnpm build` passes; `/api/pos/[id]/approve`, `/api/pos/[id]/reject`, `/api/notifications`, `/api/notifications/[id]/read`, `/notifications` all show up in the route table
- [ ] Post-merge of #4: rebase, confirm migration runs cleanly against #4's schema, manually approve a pending PO and verify email + in-app notification land for the PM