### PR TITLE
feat(e2): projects + budget audit (closes #3)

### DIFF
--- a/src/app/api/projects/[id]/archive/route.ts
+++ b/src/app/api/projects/[id]/archive/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth/guards";
+
+/**
+ * POST /api/projects/:id/archive
+ * Owner only. Sets status='archived'. Idempotent.
+ */
+export async function POST(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { data: existing, error: lookupErr } = await supabase
+    .from("projects")
+    .select("id, workspace_id, status")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (lookupErr) {
+    return NextResponse.json({ error: lookupErr.message }, { status: 500 });
+  }
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const guard = await requireRole(existing.workspace_id, "owner");
+  if (!guard.ok || guard.role !== "owner") {
+    return NextResponse.json(
+      { error: guard.ok ? "Owner only" : guard.error },
+      { status: guard.ok ? 403 : guard.status },
+    );
+  }
+
+  if (existing.status === "archived") {
+    return NextResponse.json({ project: { id, status: "archived" } });
+  }
+
+  const { data, error } = await supabase
+    .from("projects")
+    .update({ status: "archived" })
+    .eq("id", id)
+    .select("id, status")
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? "Failed to archive project" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ project: data });
+}

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth/guards";
+
+/**
+ * GET /api/projects/:id
+ * RLS handles visibility (owner/bookkeeper: any in workspace; pm: assigned only).
+ */
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("projects")
+    .select(
+      "id, workspace_id, name, budget_centavos, assigned_pm_id, status, created_at, created_by",
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (!data) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Best-effort: surface budget history when the caller can read the project.
+  // RLS applies the same predicate, so this is safe.
+  const { data: history } = await supabase
+    .from("project_budget_history")
+    .select("id, old_centavos, new_centavos, actor_id, at")
+    .eq("project_id", id)
+    .order("at", { ascending: false })
+    .limit(50);
+
+  return NextResponse.json({ project: data, budgetHistory: history ?? [] });
+}
+
+const PatchBody = z.object({
+  name: z.string().min(1).max(200).optional(),
+  budgetCentavos: z
+    .union([z.string(), z.number()])
+    .transform((v) => {
+      const s = typeof v === "number" ? Math.trunc(v).toString() : v;
+      if (!/^-?\d+$/.test(s)) throw new Error("budgetCentavos must be an integer");
+      return s;
+    })
+    .optional(),
+  assignedPmId: z.string().uuid().nullable().optional(),
+});
+
+/**
+ * PATCH /api/projects/:id
+ * Owner only. Budget changes are audited by the trigger on `projects`.
+ */
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+
+  let parsed;
+  try {
+    parsed = PatchBody.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  // Look up workspace_id so we can role-check before we attempt the update.
+  const { data: existing, error: lookupErr } = await supabase
+    .from("projects")
+    .select("id, workspace_id, status")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (lookupErr) {
+    return NextResponse.json({ error: lookupErr.message }, { status: 500 });
+  }
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const guard = await requireRole(existing.workspace_id, "owner");
+  if (!guard.ok || guard.role !== "owner") {
+    return NextResponse.json(
+      { error: guard.ok ? "Owner only" : guard.error },
+      { status: guard.ok ? 403 : guard.status },
+    );
+  }
+
+  if (existing.status === "archived") {
+    return NextResponse.json(
+      { error: "Cannot edit an archived project" },
+      { status: 409 },
+    );
+  }
+
+  const patch: Record<string, unknown> = {};
+  if (parsed.name !== undefined) patch.name = parsed.name;
+  if (parsed.budgetCentavos !== undefined)
+    patch.budget_centavos = parsed.budgetCentavos;
+  if (parsed.assignedPmId !== undefined) patch.assigned_pm_id = parsed.assignedPmId;
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("projects")
+    .update(patch)
+    .eq("id", id)
+    .select(
+      "id, workspace_id, name, budget_centavos, assigned_pm_id, status, created_at",
+    )
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? "Failed to update project" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ project: data });
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth/guards";
+
+/**
+ * GET /api/projects?workspaceId=...
+ * Returns projects in the workspace. RLS handles row-level filtering:
+ *   - Owners + bookkeepers: all projects in the workspace
+ *   - PMs: only projects assigned to them
+ */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const workspaceId = url.searchParams.get("workspaceId");
+  if (!workspaceId) {
+    return NextResponse.json(
+      { error: "workspaceId query param required" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, name, budget_centavos, assigned_pm_id, status, created_at")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // budget_centavos comes back as string from supabase-js for bigint columns;
+  // pass it through unchanged. UI converts via pesoToCentavos / centavosToPeso.
+  return NextResponse.json({ projects: data ?? [] });
+}
+
+const CreateBody = z.object({
+  workspaceId: z.string().uuid(),
+  name: z.string().min(1).max(200),
+  // Accept centavos as string (bigint-safe over JSON) or number.
+  budgetCentavos: z
+    .union([z.string(), z.number()])
+    .transform((v) => {
+      const s = typeof v === "number" ? Math.trunc(v).toString() : v;
+      if (!/^-?\d+$/.test(s)) throw new Error("budgetCentavos must be an integer");
+      return s;
+    }),
+  assignedPmId: z.string().uuid().nullable().optional(),
+});
+
+/**
+ * POST /api/projects
+ * Owner-only. Creates a project in the given workspace.
+ */
+export async function POST(req: Request) {
+  let parsed;
+  try {
+    parsed = CreateBody.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const { workspaceId, name, budgetCentavos, assignedPmId } = parsed;
+
+  const guard = await requireRole(workspaceId, "owner");
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+  // After requireRole, role === "owner" specifically (not just "satisfies").
+  if (guard.role !== "owner") {
+    return NextResponse.json({ error: "Owner only" }, { status: 403 });
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("projects")
+    .insert({
+      workspace_id: workspaceId,
+      name,
+      budget_centavos: budgetCentavos,
+      assigned_pm_id: assignedPmId ?? null,
+      created_by: guard.userId,
+    })
+    .select("id, name, budget_centavos, assigned_pm_id, status, created_at")
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? "Failed to create project" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ project: data }, { status: 201 });
+}

--- a/src/app/projects/[id]/edit-project-form.tsx
+++ b/src/app/projects/[id]/edit-project-form.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { centavosToPeso, pesoToCentavos } from "@/lib/money";
+
+type ProjectInput = {
+  id: string;
+  name: string;
+  budget_centavos: string;
+  assigned_pm_id: string | null;
+  status: "active" | "archived";
+};
+
+export function EditProjectForm({ project }: { project: ProjectInput }) {
+  const router = useRouter();
+  const [name, setName] = useState(project.name);
+  const [budget, setBudget] = useState(
+    centavosToPeso(BigInt(project.budget_centavos)),
+  );
+  const [assignedPmId, setAssignedPmId] = useState(project.assigned_pm_id ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<"save" | "archive" | null>(null);
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy("save");
+    try {
+      const budgetCentavos = pesoToCentavos(budget).toString();
+      const res = await fetch(`/api/projects/${project.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name,
+          budgetCentavos,
+          assignedPmId: assignedPmId.trim() === "" ? null : assignedPmId.trim(),
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Failed");
+      router.refresh();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function onArchive() {
+    if (!confirm("Archive this project? It will become read-only.")) return;
+    setError(null);
+    setBusy("archive");
+    try {
+      const res = await fetch(`/api/projects/${project.id}/archive`, {
+        method: "POST",
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Failed");
+      router.refresh();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <form onSubmit={onSave} className="mt-3 space-y-3 rounded border p-4">
+      <label className="block text-sm">
+        Name
+        <input
+          className="mt-1 block w-full rounded border p-2"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+      </label>
+      <label className="block text-sm">
+        Budget (₱)
+        <input
+          className="mt-1 block w-full rounded border p-2"
+          inputMode="decimal"
+          value={budget}
+          onChange={(e) => setBudget(e.target.value)}
+          required
+        />
+      </label>
+      <label className="block text-sm">
+        Assigned PM (user id)
+        <input
+          className="mt-1 block w-full rounded border p-2"
+          value={assignedPmId}
+          onChange={(e) => setAssignedPmId(e.target.value)}
+          placeholder="leave blank to unassign"
+        />
+      </label>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={busy !== null}
+          className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+        >
+          {busy === "save" ? "Saving…" : "Save changes"}
+        </button>
+        <button
+          type="button"
+          onClick={onArchive}
+          disabled={busy !== null}
+          className="rounded border px-4 py-2 text-sm font-medium text-slate-700 disabled:opacity-50"
+        >
+          {busy === "archive" ? "Archiving…" : "Archive"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { centavosToPeso } from "@/lib/money";
+import { canEditProject } from "@/lib/projects/access";
+import type { Role } from "@/lib/auth/guards";
+import { EditProjectForm } from "./edit-project-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProjectDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const { data: project } = await supabase
+    .from("projects")
+    .select(
+      "id, workspace_id, name, budget_centavos, assigned_pm_id, status, created_at",
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (!project) return notFound();
+
+  const { data: membership } = await supabase
+    .from("memberships")
+    .select("role")
+    .eq("workspace_id", project.workspace_id)
+    .eq("user_id", user.id)
+    .eq("status", "active")
+    .maybeSingle();
+
+  const role = (membership?.role ?? "pm") as Role;
+  const editable = canEditProject(role, project);
+
+  const { data: history } = await supabase
+    .from("project_budget_history")
+    .select("id, old_centavos, new_centavos, actor_id, at")
+    .eq("project_id", id)
+    .order("at", { ascending: false })
+    .limit(50);
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <Link href="/projects" className="text-sm text-slate-500 hover:underline">
+        ← Projects
+      </Link>
+      <h1 className="mt-2 text-2xl font-semibold tracking-tight">
+        {project.name}
+      </h1>
+      <p className="text-sm text-slate-500">
+        Status: {project.status} · Budget: ₱
+        {centavosToPeso(BigInt(project.budget_centavos))}
+      </p>
+
+      {editable ? (
+        <section className="mt-6">
+          <h2 className="text-sm font-medium text-slate-700">Edit</h2>
+          <EditProjectForm
+            project={{
+              id: project.id,
+              name: project.name,
+              budget_centavos: String(project.budget_centavos),
+              assigned_pm_id: project.assigned_pm_id,
+              status: project.status,
+            }}
+          />
+        </section>
+      ) : (
+        <p className="mt-4 text-sm text-slate-500">
+          {project.status === "archived"
+            ? "This project is archived."
+            : "Read-only view."}
+        </p>
+      )}
+
+      <section className="mt-8">
+        <h2 className="text-sm font-medium text-slate-700">Budget history</h2>
+        {(history ?? []).length === 0 ? (
+          <p className="mt-2 text-sm text-slate-500">No budget changes yet.</p>
+        ) : (
+          <ul className="mt-2 divide-y rounded border text-sm">
+            {(history ?? []).map((h) => (
+              <li key={h.id} className="p-3">
+                <div className="text-slate-900">
+                  ₱{centavosToPeso(BigInt(h.old_centavos))} → ₱
+                  {centavosToPeso(BigInt(h.new_centavos))}
+                </div>
+                <div className="text-xs text-slate-500">
+                  {new Date(h.at).toLocaleString()} ·{" "}
+                  {h.actor_id ?? "system"}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/projects/new-project-form.tsx
+++ b/src/app/projects/new-project-form.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { pesoToCentavos } from "@/lib/money";
+
+type Workspace = { id: string; name: string };
+
+export function NewProjectForm({ workspaces }: { workspaces: Workspace[] }) {
+  const router = useRouter();
+  const [workspaceId, setWorkspaceId] = useState(workspaces[0]?.id ?? "");
+  const [name, setName] = useState("");
+  const [budget, setBudget] = useState("0.00");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const budgetCentavos = pesoToCentavos(budget).toString();
+      const res = await fetch("/api/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ workspaceId, name, budgetCentavos }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Failed");
+      router.refresh();
+      setName("");
+      setBudget("0.00");
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="mt-3 space-y-3 rounded border p-4">
+      {workspaces.length > 1 && (
+        <label className="block text-sm">
+          Workspace
+          <select
+            className="mt-1 block w-full rounded border p-2"
+            value={workspaceId}
+            onChange={(e) => setWorkspaceId(e.target.value)}
+          >
+            {workspaces.map((w) => (
+              <option key={w.id} value={w.id}>
+                {w.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      <label className="block text-sm">
+        Name
+        <input
+          className="mt-1 block w-full rounded border p-2"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+      </label>
+      <label className="block text-sm">
+        Budget (₱)
+        <input
+          className="mt-1 block w-full rounded border p-2"
+          inputMode="decimal"
+          value={budget}
+          onChange={(e) => setBudget(e.target.value)}
+          required
+        />
+      </label>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <button
+        type="submit"
+        disabled={submitting || !workspaceId}
+        className="rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+      >
+        {submitting ? "Creating…" : "Create project"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { centavosToPeso } from "@/lib/money";
+import { NewProjectForm } from "./new-project-form";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * /projects — list + create form.
+ *
+ * Shows projects across all workspaces the user is a member of. RLS scopes
+ * by workspace and (for PMs) by assignment. The create form is shown for
+ * each workspace where the user is an owner.
+ */
+export default async function ProjectsPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: memberships } = await supabase
+    .from("memberships")
+    .select("workspace_id, role, workspaces(name)")
+    .eq("user_id", user.id)
+    .eq("status", "active");
+
+  const ownerWorkspaces = (memberships ?? []).filter((m) => m.role === "owner");
+
+  const { data: projects } = await supabase
+    .from("projects")
+    .select("id, workspace_id, name, budget_centavos, assigned_pm_id, status, created_at")
+    .order("created_at", { ascending: false });
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="text-2xl font-semibold tracking-tight">Projects</h1>
+
+      <section className="mt-6">
+        <h2 className="text-sm font-medium text-slate-700">Your projects</h2>
+        {(projects ?? []).length === 0 ? (
+          <p className="mt-2 text-sm text-slate-500">No projects yet.</p>
+        ) : (
+          <ul className="mt-2 divide-y rounded border">
+            {(projects ?? []).map((p) => (
+              <li key={p.id} className="flex items-center justify-between p-3">
+                <div>
+                  <Link
+                    href={`/projects/${p.id}`}
+                    className="font-medium text-slate-900 hover:underline"
+                  >
+                    {p.name}
+                  </Link>
+                  <div className="text-xs text-slate-500">
+                    Budget: ₱{centavosToPeso(BigInt(p.budget_centavos))} ·{" "}
+                    {p.status}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {ownerWorkspaces.length > 0 && (
+        <section className="mt-8">
+          <h2 className="text-sm font-medium text-slate-700">
+            Create a project
+          </h2>
+          <NewProjectForm
+            workspaces={ownerWorkspaces.map((m) => ({
+              id: m.workspace_id,
+              // workspaces is joined; supabase-js types it as array | object.
+              name:
+                (Array.isArray(m.workspaces)
+                  ? m.workspaces[0]?.name
+                  : (m.workspaces as { name?: string } | null)?.name) ??
+                "Workspace",
+            }))}
+          />
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,0 +1,61 @@
+/**
+ * Money helpers. ADR-4: amounts are stored as integer centavos (bigint) and
+ * never converted to floats for math. Conversions to/from human-readable
+ * pesos happen only at the UI/IO boundary.
+ *
+ * 1 peso = 100 centavos.
+ */
+
+const CENTAVOS_PER_PESO = 100n;
+
+/**
+ * Format a centavo amount as a peso string with 2 decimals.
+ * Negative values are supported. No currency symbol — caller adds "₱".
+ *
+ * Examples:
+ *   centavosToPeso(0n)        -> "0.00"
+ *   centavosToPeso(150n)      -> "1.50"
+ *   centavosToPeso(-12345n)   -> "-123.45"
+ *   centavosToPeso(100000000000n) -> "1000000000.00"
+ */
+export function centavosToPeso(n: bigint): string {
+  const negative = n < 0n;
+  const abs = negative ? -n : n;
+  const whole = abs / CENTAVOS_PER_PESO;
+  const frac = abs % CENTAVOS_PER_PESO;
+  const fracStr = frac.toString().padStart(2, "0");
+  return `${negative ? "-" : ""}${whole.toString()}.${fracStr}`;
+}
+
+/**
+ * Parse a user-entered peso string into bigint centavos.
+ * Accepts:
+ *   - optional leading sign
+ *   - optional ₱ or whitespace
+ *   - thousands separators (",")
+ *   - 0, 1, or 2 fractional digits
+ *
+ * Throws on invalid input. Always returns an integer number of centavos.
+ *
+ *   pesoToCentavos("0")        -> 0n
+ *   pesoToCentavos("1.50")     -> 150n
+ *   pesoToCentavos("₱1,234.5") -> 123450n
+ *   pesoToCentavos("-0.01")    -> -1n
+ */
+export function pesoToCentavos(input: string): bigint {
+  if (typeof input !== "string") {
+    throw new TypeError("pesoToCentavos expects a string");
+  }
+  const cleaned = input.replace(/[₱\s,]/g, "").trim();
+  if (cleaned === "" || cleaned === "-" || cleaned === "+") {
+    throw new Error(`Invalid peso amount: ${JSON.stringify(input)}`);
+  }
+  const match = /^([+-]?)(\d+)(?:\.(\d{1,2}))?$/.exec(cleaned);
+  if (!match) {
+    throw new Error(`Invalid peso amount: ${JSON.stringify(input)}`);
+  }
+  const [, sign, whole, fracRaw = ""] = match;
+  const frac = (fracRaw + "00").slice(0, 2);
+  const total = BigInt(whole) * CENTAVOS_PER_PESO + BigInt(frac);
+  return sign === "-" ? -total : total;
+}

--- a/src/lib/projects/access.ts
+++ b/src/lib/projects/access.ts
@@ -1,0 +1,32 @@
+import type { Role } from "@/lib/auth/guards";
+
+export type ProjectAccessShape = {
+  assigned_pm_id: string | null;
+  status?: "active" | "archived";
+};
+
+/**
+ * Owners can edit any project in their workspace.
+ * PMs and bookkeepers cannot edit projects (RLS also enforces this).
+ * Archived projects are read-only.
+ */
+export function canEditProject(
+  role: Role,
+  project: ProjectAccessShape,
+): boolean {
+  if (project.status === "archived") return false;
+  return role === "owner";
+}
+
+/**
+ * SELECT permission mirror of the RLS policy. Useful for UI gating.
+ */
+export function canViewProject(
+  role: Role,
+  userId: string,
+  project: ProjectAccessShape,
+): boolean {
+  if (role === "owner" || role === "bookkeeper") return true;
+  if (role === "pm") return project.assigned_pm_id === userId;
+  return false;
+}

--- a/supabase/migrations/20260430200000_e2_projects.sql
+++ b/supabase/migrations/20260430200000_e2_projects.sql
@@ -1,0 +1,144 @@
+-- E2: Projects + Budget audit
+-- Tables: projects, project_budget_history
+-- ADR-4: money is bigint centavos; never floats.
+-- ADR-6: RLS scoped by workspace_id; route handlers + middleware enforce auth.
+-- Reuses auth.user_workspace_ids() from the e1 migration.
+
+-- ---------------------------------------------------------------------------
+-- Enums
+-- ---------------------------------------------------------------------------
+do $$ begin
+  create type project_status as enum ('active', 'archived');
+exception when duplicate_object then null; end $$;
+
+-- ---------------------------------------------------------------------------
+-- Helper: current user's role in a given workspace (or null)
+-- ---------------------------------------------------------------------------
+-- Other epics may reuse this for role-aware RLS predicates.
+create or replace function auth.user_role_in(target_workspace_id uuid)
+returns membership_role
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select role
+  from public.memberships
+  where user_id = auth.uid()
+    and workspace_id = target_workspace_id
+    and status = 'active'
+  limit 1;
+$$;
+
+grant execute on function auth.user_role_in(uuid) to authenticated, anon;
+
+-- ---------------------------------------------------------------------------
+-- Tables
+-- ---------------------------------------------------------------------------
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references public.workspaces(id) on delete cascade,
+  name text not null,
+  budget_centavos bigint not null default 0 check (budget_centavos >= 0),
+  assigned_pm_id uuid references auth.users(id) on delete set null,
+  status project_status not null default 'active',
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists projects_workspace_idx on public.projects(workspace_id);
+create index if not exists projects_assigned_pm_idx on public.projects(assigned_pm_id);
+
+create table if not exists public.project_budget_history (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  old_centavos bigint not null,
+  new_centavos bigint not null,
+  actor_id uuid references auth.users(id) on delete set null,
+  at timestamptz not null default now()
+);
+
+create index if not exists pbh_project_idx on public.project_budget_history(project_id, at desc);
+
+-- ---------------------------------------------------------------------------
+-- Trigger: capture every budget change
+-- ---------------------------------------------------------------------------
+create or replace function public.log_project_budget_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.budget_centavos is distinct from old.budget_centavos then
+    insert into public.project_budget_history (
+      project_id, old_centavos, new_centavos, actor_id
+    ) values (
+      new.id, old.budget_centavos, new.budget_centavos, auth.uid()
+    );
+  end if;
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_projects_budget_history on public.projects;
+create trigger trg_projects_budget_history
+  before update on public.projects
+  for each row
+  execute function public.log_project_budget_change();
+
+-- ---------------------------------------------------------------------------
+-- RLS
+-- ---------------------------------------------------------------------------
+alter table public.projects enable row level security;
+alter table public.project_budget_history enable row level security;
+
+-- projects SELECT:
+--   - Owners & bookkeepers: any project in their workspace
+--   - PMs: only projects assigned to them
+drop policy if exists "projects_select_workspace" on public.projects;
+create policy "projects_select_workspace" on public.projects
+  for select using (
+    workspace_id in (select auth.user_workspace_ids())
+    and (
+      auth.user_role_in(workspace_id) in ('owner', 'bookkeeper')
+      or (auth.user_role_in(workspace_id) = 'pm' and assigned_pm_id = auth.uid())
+    )
+  );
+
+-- projects INSERT: owners only
+drop policy if exists "projects_insert_owner" on public.projects;
+create policy "projects_insert_owner" on public.projects
+  for insert with check (
+    auth.user_role_in(workspace_id) = 'owner'
+  );
+
+-- projects UPDATE: owners only (covers edits + archive transitions)
+drop policy if exists "projects_update_owner" on public.projects;
+create policy "projects_update_owner" on public.projects
+  for update using (
+    auth.user_role_in(workspace_id) = 'owner'
+  ) with check (
+    auth.user_role_in(workspace_id) = 'owner'
+  );
+
+-- project_budget_history SELECT: anyone who can SELECT the parent project
+drop policy if exists "pbh_select_via_project" on public.project_budget_history;
+create policy "pbh_select_via_project" on public.project_budget_history
+  for select using (
+    exists (
+      select 1 from public.projects p
+      where p.id = project_budget_history.project_id
+        and p.workspace_id in (select auth.user_workspace_ids())
+        and (
+          auth.user_role_in(p.workspace_id) in ('owner', 'bookkeeper')
+          or (auth.user_role_in(p.workspace_id) = 'pm' and p.assigned_pm_id = auth.uid())
+        )
+    )
+  );
+
+-- No INSERT/UPDATE/DELETE policies on project_budget_history:
+-- the trigger runs as security definer, so it bypasses RLS for inserts.
+-- Direct writes from end-user roles are denied by default.

--- a/tests/integration/projects-flow.test.ts
+++ b/tests/integration/projects-flow.test.ts
@@ -1,0 +1,13 @@
+import { describe, it } from "vitest";
+
+// TODO(issue-3): wire up `supabase start` integration tests for projects:
+//   - owner creates project, edits budget, archive
+//   - audit row inserted on every budget change
+//   - PM sees only assigned project, cannot mutate
+// Skipping until Docker/local Supabase is reliably available, consistent
+// with the approach in tests/integration/invite-flow.test.ts.
+describe.skip("projects flow (integration)", () => {
+  it("owner create -> edit -> archive with audit history", () => {
+    // placeholder
+  });
+});

--- a/tests/unit/money.test.ts
+++ b/tests/unit/money.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { centavosToPeso, pesoToCentavos } from "@/lib/money";
+
+describe("centavosToPeso", () => {
+  it("formats zero", () => {
+    expect(centavosToPeso(0n)).toBe("0.00");
+  });
+
+  it("pads single-digit fraction", () => {
+    expect(centavosToPeso(5n)).toBe("0.05");
+    expect(centavosToPeso(50n)).toBe("0.50");
+  });
+
+  it("formats whole pesos", () => {
+    expect(centavosToPeso(100n)).toBe("1.00");
+    expect(centavosToPeso(12345n)).toBe("123.45");
+  });
+
+  it("supports negatives", () => {
+    expect(centavosToPeso(-1n)).toBe("-0.01");
+    expect(centavosToPeso(-12345n)).toBe("-123.45");
+  });
+
+  it("handles very large bigints without precision loss", () => {
+    const big = 9_999_999_999_999_99n; // 9_999_999_999_999.99 pesos
+    expect(centavosToPeso(big)).toBe("9999999999999.99");
+  });
+});
+
+describe("pesoToCentavos", () => {
+  it("parses zero forms", () => {
+    expect(pesoToCentavos("0")).toBe(0n);
+    expect(pesoToCentavos("0.00")).toBe(0n);
+    expect(pesoToCentavos("0.0")).toBe(0n);
+  });
+
+  it("parses whole and fractional pesos", () => {
+    expect(pesoToCentavos("1")).toBe(100n);
+    expect(pesoToCentavos("1.5")).toBe(150n);
+    expect(pesoToCentavos("1.50")).toBe(150n);
+    expect(pesoToCentavos("123.45")).toBe(12345n);
+  });
+
+  it("strips currency symbol, whitespace, and commas", () => {
+    expect(pesoToCentavos("₱1,234.50")).toBe(123450n);
+    expect(pesoToCentavos("  ₱ 1,000  ")).toBe(100000n);
+  });
+
+  it("supports negatives", () => {
+    expect(pesoToCentavos("-0.01")).toBe(-1n);
+    expect(pesoToCentavos("-123.45")).toBe(-12345n);
+  });
+
+  it("rejects invalid input", () => {
+    expect(() => pesoToCentavos("")).toThrow();
+    expect(() => pesoToCentavos("abc")).toThrow();
+    expect(() => pesoToCentavos("1.234")).toThrow();
+    expect(() => pesoToCentavos("1.2.3")).toThrow();
+    expect(() => pesoToCentavos("--1")).toThrow();
+  });
+
+  it("round-trips", () => {
+    const samples = [
+      0n,
+      1n,
+      99n,
+      100n,
+      12345n,
+      -12345n,
+      9_999_999_999_999_99n,
+    ];
+    for (const c of samples) {
+      expect(pesoToCentavos(centavosToPeso(c))).toBe(c);
+    }
+  });
+});

--- a/tests/unit/projects-access.test.ts
+++ b/tests/unit/projects-access.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { canEditProject, canViewProject } from "@/lib/projects/access";
+
+describe("canEditProject", () => {
+  it("owner can edit active projects", () => {
+    expect(canEditProject("owner", { assigned_pm_id: null, status: "active" })).toBe(true);
+  });
+
+  it("owner cannot edit archived projects", () => {
+    expect(canEditProject("owner", { assigned_pm_id: null, status: "archived" })).toBe(false);
+  });
+
+  it("pm cannot edit even when assigned", () => {
+    expect(canEditProject("pm", { assigned_pm_id: "u1", status: "active" })).toBe(false);
+  });
+
+  it("bookkeeper cannot edit", () => {
+    expect(canEditProject("bookkeeper", { assigned_pm_id: null, status: "active" })).toBe(false);
+  });
+});
+
+describe("canViewProject", () => {
+  it("owner sees any project", () => {
+    expect(canViewProject("owner", "u1", { assigned_pm_id: null })).toBe(true);
+  });
+
+  it("bookkeeper sees any project", () => {
+    expect(canViewProject("bookkeeper", "u1", { assigned_pm_id: null })).toBe(true);
+  });
+
+  it("pm sees only assigned project", () => {
+    expect(canViewProject("pm", "u1", { assigned_pm_id: "u1" })).toBe(true);
+    expect(canViewProject("pm", "u1", { assigned_pm_id: "u2" })).toBe(false);
+    expect(canViewProject("pm", "u1", { assigned_pm_id: null })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `projects` + `project_budget_history` tables, `project_status` enum, and `auth.user_role_in()` helper in `supabase/migrations/20260430200000_e2_projects.sql`. Reuses `auth.user_workspace_ids()` from the e1 migration.
- Budget audit is enforced by a Postgres trigger (`log_project_budget_change`, security definer) that writes a `project_budget_history` row on every `budget_centavos` change, capturing `auth.uid()` as the actor. App-side code cannot bypass it.
- RLS: workspace members SELECT (PMs only see projects where `assigned_pm_id = auth.uid()`); owners-only INSERT/UPDATE (archive is an UPDATE of `status`).
- API routes under `src/app/api/projects/`: `GET/POST /api/projects`, `GET/PATCH /api/projects/:id`, `POST /api/projects/:id/archive`. All zod-validated; owner gate via `requireRole`. PATCH refuses to mutate archived projects.
- Minimal UI: `/projects` (list + create) and `/projects/[id]` (edit + archive + budget history). Money is rendered in pesos with the ₱ symbol via `src/lib/money.ts` (`centavosToPeso` / `pesoToCentavos`, ADR-4).
- `canEditProject` / `canViewProject` guards in `src/lib/projects/access.ts` mirror RLS for UI gating.
- Vitest unit tests for `money.ts` (round-trip, zero, negative, large bigints) and `projects/access.ts`. Integration test for the full flow is `describe.skip`ed with a TODO, matching issue #2's approach when Docker isn't available.

## Non-obvious decisions
- **Budget history via trigger, not app code.** The trigger runs as `security definer` and inserts directly into `project_budget_history`, which has no INSERT policy for end-user roles. This makes the audit airtight even if a future code path bypasses the API layer.
- **`auth.user_role_in(workspace_id)` helper** is defined in this migration so later epics (POs, approvals) can reuse it for role-aware RLS predicates without re-querying memberships inline.
- `budget_centavos` is `bigint` with `>= 0` check. supabase-js returns bigints as strings on the wire; the API forwards them as-is and the UI converts via `BigInt(...)` + `centavosToPeso`.
- The `assigned_pm_id` field is a free-form user id input in the edit form for now — a member-picker UI is out of scope for issue #3.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (26 unit tests; 2 integration tests skipped with TODO)
- [x] `pnpm build` succeeds; `/projects` and `/projects/[id]` render in the route table
- [ ] Manual: with a local Supabase, owner can create/edit/archive a project and budget edits surface in `project_budget_history`
- [ ] Manual: assigned PM sees only their project on `/projects`; non-assigned PM sees none