### PR TITLE
feat(e3): purchase orders + state machine (closes #4)

### DIFF
--- a/src/app/api/pos/[id]/attachments/route.ts
+++ b/src/app/api/pos/[id]/attachments/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { ALLOWED_ATTACHMENT_TYPES } from "@/lib/po/types";
+
+const Body = z.object({
+  storage_path: z.string().min(1),
+  filename: z.string().min(1).max(255),
+  content_type: z.enum(ALLOWED_ATTACHMENT_TYPES),
+  size_bytes: z.number().int().nonnegative(),
+});
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  let parsed;
+  try {
+    parsed = Body.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  // Path must start with `<workspace_id>/<po_id>/`.
+  const { data: po, error: poErr } = await supabase
+    .from("purchase_orders")
+    .select("id, workspace_id, created_by, status")
+    .eq("id", id)
+    .maybeSingle();
+  if (poErr) return NextResponse.json({ error: poErr.message }, { status: 500 });
+  if (!po) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (po.created_by !== user.id) {
+    return NextResponse.json({ error: "Not your draft" }, { status: 403 });
+  }
+  if (po.status !== "draft") {
+    return NextResponse.json(
+      { error: `Cannot attach to PO in status ${po.status}` },
+      { status: 409 },
+    );
+  }
+
+  const expectedPrefix = `${po.workspace_id}/${po.id}/`;
+  if (!parsed.storage_path.startsWith(expectedPrefix)) {
+    return NextResponse.json(
+      { error: "storage_path outside scoped folder" },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("po_attachments")
+    .insert({
+      po_id: id,
+      storage_path: parsed.storage_path,
+      filename: parsed.filename,
+      content_type: parsed.content_type,
+      size_bytes: parsed.size_bytes,
+      uploaded_by: user.id,
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? "Failed to record attachment" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ id: data.id });
+}

--- a/src/app/api/pos/[id]/attachments/sign/route.ts
+++ b/src/app/api/pos/[id]/attachments/sign/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { ALLOWED_ATTACHMENT_TYPES } from "@/lib/po/types";
+
+const Body = z.object({
+  filename: z.string().min(1).max(255),
+  content_type: z.enum(ALLOWED_ATTACHMENT_TYPES),
+});
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  let parsed;
+  try {
+    parsed = Body.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  const { data: po, error: poErr } = await supabase
+    .from("purchase_orders")
+    .select("id, workspace_id, created_by, status")
+    .eq("id", id)
+    .maybeSingle();
+  if (poErr) return NextResponse.json({ error: poErr.message }, { status: 500 });
+  if (!po) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (po.created_by !== user.id) {
+    return NextResponse.json({ error: "Not your draft" }, { status: 403 });
+  }
+  if (po.status !== "draft") {
+    return NextResponse.json(
+      { error: `Cannot upload to PO in status ${po.status}` },
+      { status: 409 },
+    );
+  }
+
+  // Sanitize filename — strip path segments, keep base name only.
+  const safe = parsed.filename.replace(/[/\\]/g, "_");
+  const path = `${po.workspace_id}/${po.id}/${Date.now()}-${safe}`;
+
+  const { data, error } = await supabase.storage
+    .from("po-attachments")
+    .createSignedUploadUrl(path);
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? "Failed to sign upload" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    storage_path: path,
+    signed_url: data.signedUrl,
+    token: data.token,
+    content_type: parsed.content_type,
+  });
+}

--- a/src/app/api/pos/[id]/route.ts
+++ b/src/app/api/pos/[id]/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { UpdatePOInput } from "@/lib/po/types";
+import { canEdit } from "@/lib/po/state-machine";
+import { lineTotalCentavos, sumCentavos } from "@/lib/po/money";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createSupabaseServerClient();
+
+  const { data: po, error } = await supabase
+    .from("purchase_orders")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!po) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const [{ data: lineItems }, { data: attachments }, { data: history }] =
+    await Promise.all([
+      supabase.from("po_line_items").select("*").eq("po_id", id).order("created_at"),
+      supabase.from("po_attachments").select("*").eq("po_id", id).order("created_at"),
+      supabase.from("po_status_history").select("*").eq("po_id", id).order("at"),
+    ]);
+
+  return NextResponse.json({
+    purchase_order: po,
+    line_items: lineItems ?? [],
+    attachments: attachments ?? [],
+    status_history: history ?? [],
+  });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  let parsed;
+  try {
+    parsed = UpdatePOInput.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  const { data: po, error: poErr } = await supabase
+    .from("purchase_orders")
+    .select("id, status, created_by, workspace_id")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (poErr) return NextResponse.json({ error: poErr.message }, { status: 500 });
+  if (!po) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  if (po.created_by !== user.id) {
+    return NextResponse.json({ error: "Not your draft" }, { status: 403 });
+  }
+  if (!canEdit(po.status)) {
+    return NextResponse.json(
+      { error: `Cannot edit PO in status ${po.status}` },
+      { status: 409 },
+    );
+  }
+
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (parsed.supplier_name !== undefined) update.supplier_name = parsed.supplier_name;
+  if (parsed.note !== undefined) update.note = parsed.note;
+
+  if (parsed.line_items) {
+    const lineTotals = parsed.line_items.map((li) =>
+      lineTotalCentavos(li.qty, li.unit_price_centavos),
+    );
+    update.total_centavos = sumCentavos(lineTotals);
+
+    // Replace line items wholesale (simplest semantics for draft edits).
+    const { error: delErr } = await supabase
+      .from("po_line_items")
+      .delete()
+      .eq("po_id", id);
+    if (delErr) return NextResponse.json({ error: delErr.message }, { status: 500 });
+
+    if (parsed.line_items.length > 0) {
+      const { error: insErr } = await supabase.from("po_line_items").insert(
+        parsed.line_items.map((li, i) => ({
+          po_id: id,
+          description: li.description,
+          qty: li.qty,
+          unit_price_centavos: li.unit_price_centavos,
+          line_total_centavos: lineTotals[i],
+        })),
+      );
+      if (insErr) return NextResponse.json({ error: insErr.message }, { status: 500 });
+    }
+  }
+
+  const { error: updErr } = await supabase
+    .from("purchase_orders")
+    .update(update)
+    .eq("id", id);
+  if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/pos/[id]/submit/route.ts
+++ b/src/app/api/pos/[id]/submit/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/service-role";
+import { transition } from "@/lib/po/state-machine";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  const { data: po, error: poErr } = await supabase
+    .from("purchase_orders")
+    .select("id, status, created_by, workspace_id, po_number, total_centavos")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (poErr) return NextResponse.json({ error: poErr.message }, { status: 500 });
+  if (!po) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  if (po.created_by !== user.id) {
+    return NextResponse.json({ error: "Only the PM owner can submit" }, { status: 403 });
+  }
+
+  const t = transition(po.status, "submit");
+  if (!t.ok) return NextResponse.json({ error: t.error }, { status: 409 });
+
+  // Need at least one line item to submit.
+  const { count: liCount } = await supabase
+    .from("po_line_items")
+    .select("id", { count: "exact", head: true })
+    .eq("po_id", id);
+  if (!liCount || liCount === 0) {
+    return NextResponse.json(
+      { error: "Cannot submit a PO with no line items" },
+      { status: 400 },
+    );
+  }
+
+  // Reserve the PO number via service-role (bypasses counter RLS) but only
+  // after we've validated the user owns the draft above.
+  const admin = createSupabaseServiceRoleClient();
+  const { data: poNumberData, error: rpcErr } = await admin.rpc("next_po_number", {
+    p_workspace_id: po.workspace_id,
+  });
+  if (rpcErr || !poNumberData) {
+    return NextResponse.json(
+      { error: rpcErr?.message ?? "Failed to assign PO number" },
+      { status: 500 },
+    );
+  }
+  const poNumber = poNumberData as unknown as string;
+
+  const submittedAt = new Date().toISOString();
+  const { error: updErr } = await supabase
+    .from("purchase_orders")
+    .update({
+      status: t.to,
+      po_number: poNumber,
+      submitted_at: submittedAt,
+      updated_at: submittedAt,
+    })
+    .eq("id", id);
+  if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
+
+  // Status history. Service-role write — RLS denies direct inserts.
+  const { error: histErr } = await admin.from("po_status_history").insert({
+    po_id: id,
+    from_status: po.status,
+    to_status: t.to,
+    actor_id: user.id,
+  });
+  if (histErr) {
+    return NextResponse.json({ error: histErr.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, po_number: poNumber, status: t.to });
+}

--- a/src/app/api/pos/route.ts
+++ b/src/app/api/pos/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { requireRole } from "@/lib/auth/guards";
+import { CreatePOInput } from "@/lib/po/types";
+import { lineTotalCentavos, sumCentavos } from "@/lib/po/money";
+
+export async function GET() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  // RLS handles scoping (owner sees workspace, PM sees own).
+  const { data, error } = await supabase
+    .from("purchase_orders")
+    .select(
+      "id, workspace_id, project_id, po_number, supplier_name, total_centavos, status, created_by, created_at, submitted_at",
+    )
+    .order("created_at", { ascending: false });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ purchase_orders: data ?? [] });
+}
+
+export async function POST(req: Request) {
+  let parsed;
+  try {
+    parsed = CreatePOInput.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Invalid body", details: (err as Error).message },
+      { status: 400 },
+    );
+  }
+
+  const guard = await requireRole(parsed.workspace_id, "pm");
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  const lineTotals = parsed.line_items.map((li) =>
+    lineTotalCentavos(li.qty, li.unit_price_centavos),
+  );
+  const total = sumCentavos(lineTotals);
+
+  const { data: po, error: poErr } = await supabase
+    .from("purchase_orders")
+    .insert({
+      workspace_id: parsed.workspace_id,
+      project_id: parsed.project_id,
+      supplier_name: parsed.supplier_name,
+      note: parsed.note ?? null,
+      total_centavos: total,
+      status: "draft",
+      created_by: guard.userId,
+    })
+    .select("id")
+    .single();
+
+  if (poErr || !po) {
+    return NextResponse.json(
+      { error: poErr?.message ?? "Failed to create PO" },
+      { status: 500 },
+    );
+  }
+
+  if (parsed.line_items.length > 0) {
+    const { error: liErr } = await supabase.from("po_line_items").insert(
+      parsed.line_items.map((li, i) => ({
+        po_id: po.id,
+        description: li.description,
+        qty: li.qty,
+        unit_price_centavos: li.unit_price_centavos,
+        line_total_centavos: lineTotals[i],
+      })),
+    );
+    if (liErr) {
+      return NextResponse.json({ error: liErr.message }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json({ id: po.id, status: "draft", total_centavos: total });
+}

--- a/src/app/pos/[id]/page.tsx
+++ b/src/app/pos/[id]/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { createSupabaseBrowserClient } from "@/lib/supabase/browser";
+import { centavosToPeso } from "@/lib/po/money";
+import { ALLOWED_ATTACHMENT_TYPES, type AllowedAttachmentType } from "@/lib/po/types";
+
+type PO = {
+  id: string;
+  status: "draft" | "pending" | "approved" | "rejected";
+  po_number: string | null;
+  supplier_name: string;
+  total_centavos: number;
+  note: string | null;
+  created_by: string;
+  workspace_id: string;
+};
+
+type LineItem = {
+  id: string;
+  description: string;
+  qty: number;
+  unit_price_centavos: number;
+  line_total_centavos: number;
+};
+
+type Attachment = {
+  id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+};
+
+export default function POPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const [po, setPo] = useState<PO | null>(null);
+  const [items, setItems] = useState<LineItem[]>([]);
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/pos/${id}`);
+    const json = await res.json();
+    if (!res.ok) {
+      setErr(json.error ?? "Failed to load");
+      return;
+    }
+    setPo(json.purchase_order);
+    setItems(json.line_items);
+    setAttachments(json.attachments);
+  }, [id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function submit() {
+    setErr(null);
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/pos/${id}/submit`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Failed");
+      await load();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function uploadFile(file: File) {
+    if (!po) return;
+    setErr(null);
+    setBusy(true);
+    try {
+      if (!ALLOWED_ATTACHMENT_TYPES.includes(file.type as AllowedAttachmentType)) {
+        throw new Error(`Unsupported file type: ${file.type}`);
+      }
+
+      const signRes = await fetch(`/api/pos/${id}/attachments/sign`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ filename: file.name, content_type: file.type }),
+      });
+      const signJson = await signRes.json();
+      if (!signRes.ok) throw new Error(signJson.error ?? "Failed to sign");
+
+      const supabase = createSupabaseBrowserClient();
+      const { error: upErr } = await supabase.storage
+        .from("po-attachments")
+        .uploadToSignedUrl(signJson.storage_path, signJson.token, file, {
+          contentType: file.type,
+        });
+      if (upErr) throw upErr;
+
+      const metaRes = await fetch(`/api/pos/${id}/attachments`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          storage_path: signJson.storage_path,
+          filename: file.name,
+          content_type: file.type,
+          size_bytes: file.size,
+        }),
+      });
+      const metaJson = await metaRes.json();
+      if (!metaRes.ok) throw new Error(metaJson.error ?? "Failed to record");
+      await load();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (err && !po) return <main className="p-8 text-red-600">{err}</main>;
+  if (!po) return <main className="p-8">Loading…</main>;
+
+  return (
+    <main className="mx-auto max-w-2xl p-8">
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-2xl font-semibold">
+          {po.po_number ?? "Draft PO"}{" "}
+          <span className="ml-2 text-sm uppercase tracking-wide text-slate-500">
+            {po.status}
+          </span>
+        </h1>
+      </header>
+
+      <section className="mt-4 rounded border border-slate-200 p-4">
+        <p>
+          <span className="font-medium">Supplier:</span> {po.supplier_name}
+        </p>
+        <p>
+          <span className="font-medium">Total:</span> {centavosToPeso(po.total_centavos)}
+        </p>
+        {po.note && <p className="mt-2 text-sm">{po.note}</p>}
+      </section>
+
+      <section className="mt-4">
+        <h2 className="text-lg font-medium">Line items</h2>
+        <ul className="mt-2 space-y-1 text-sm">
+          {items.map((li) => (
+            <li key={li.id} className="flex justify-between">
+              <span>
+                {li.description} ({li.qty} × {centavosToPeso(li.unit_price_centavos)})
+              </span>
+              <span>{centavosToPeso(li.line_total_centavos)}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mt-4">
+        <h2 className="text-lg font-medium">Attachments</h2>
+        <ul className="mt-2 space-y-1 text-sm">
+          {attachments.map((a) => (
+            <li key={a.id}>
+              {a.filename} <span className="text-slate-500">({a.content_type})</span>
+            </li>
+          ))}
+        </ul>
+        {po.status === "draft" && (
+          <input
+            type="file"
+            accept={ALLOWED_ATTACHMENT_TYPES.join(",")}
+            className="mt-2"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) void uploadFile(f);
+            }}
+          />
+        )}
+      </section>
+
+      {err && <p className="mt-4 text-sm text-red-600">{err}</p>}
+
+      {po.status === "draft" && (
+        <button
+          type="button"
+          onClick={submit}
+          disabled={busy || items.length === 0}
+          className="mt-6 rounded bg-slate-900 px-4 py-2 text-sm text-white disabled:opacity-50"
+        >
+          {busy ? "Submitting..." : "Submit for approval"}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={() => router.push("/app")}
+        className="mt-6 ml-2 rounded border border-slate-300 px-4 py-2 text-sm"
+      >
+        Back
+      </button>
+    </main>
+  );
+}

--- a/src/app/pos/new/page.tsx
+++ b/src/app/pos/new/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { createSupabaseBrowserClient } from "@/lib/supabase/browser";
+import { centavosToPeso, lineTotalCentavos, sumCentavos } from "@/lib/po/money";
+import { ALLOWED_ATTACHMENT_TYPES } from "@/lib/po/types";
+
+type LineRow = { description: string; qty: string; unit_price_pesos: string };
+type Workspace = { id: string; name: string };
+
+function pesosToCentavos(p: string): number {
+  const n = Number(p);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.round(n * 100);
+}
+
+export default function NewPOPageWrapper() {
+  return (
+    <Suspense fallback={<main className="p-8">Loading…</main>}>
+      <NewPOPage />
+    </Suspense>
+  );
+}
+
+function NewPOPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const projectId = params.get("projectId") ?? "";
+
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [workspaceId, setWorkspaceId] = useState("");
+  const [supplier, setSupplier] = useState("");
+  const [note, setNote] = useState("");
+  const [lines, setLines] = useState<LineRow[]>([
+    { description: "", qty: "1", unit_price_pesos: "" },
+  ]);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const supabase = createSupabaseBrowserClient();
+      const { data } = await supabase
+        .from("memberships")
+        .select("workspace:workspaces(id, name), role, status")
+        .eq("status", "active");
+      const list = ((data ?? []) as Array<{ workspace: Workspace | Workspace[] | null }>)
+        .map((m) => (Array.isArray(m.workspace) ? m.workspace[0] : m.workspace))
+        .filter((w): w is Workspace => !!w);
+      setWorkspaces(list);
+      if (list[0]) setWorkspaceId(list[0].id);
+    })();
+  }, []);
+
+  const totalCentavos = useMemo(
+    () =>
+      sumCentavos(
+        lines.map((l) => lineTotalCentavos(Number(l.qty || 0), pesosToCentavos(l.unit_price_pesos))),
+      ),
+    [lines],
+  );
+
+  function updateLine(i: number, patch: Partial<LineRow>) {
+    setLines((prev) => prev.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
+  }
+
+  function addLine() {
+    setLines((prev) => [...prev, { description: "", qty: "1", unit_price_pesos: "" }]);
+  }
+
+  function removeLine(i: number) {
+    setLines((prev) => prev.filter((_, idx) => idx !== i));
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    setBusy(true);
+    try {
+      const res = await fetch("/api/pos", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          workspace_id: workspaceId,
+          project_id: projectId,
+          supplier_name: supplier,
+          note: note || null,
+          line_items: lines
+            .filter((l) => l.description.trim().length > 0)
+            .map((l) => ({
+              description: l.description,
+              qty: Number(l.qty),
+              unit_price_centavos: pesosToCentavos(l.unit_price_pesos),
+            })),
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Failed");
+      router.push(`/pos/${json.id}`);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl p-8">
+      <h1 className="text-2xl font-semibold">New Purchase Order</h1>
+      <form onSubmit={submit} className="mt-6 space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Workspace</label>
+          <select
+            className="mt-1 w-full rounded border border-slate-300 p-2"
+            value={workspaceId}
+            onChange={(e) => setWorkspaceId(e.target.value)}
+          >
+            {workspaces.map((w) => (
+              <option key={w.id} value={w.id}>
+                {w.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Project ID</label>
+          <input
+            className="mt-1 w-full rounded border border-slate-300 p-2"
+            value={projectId}
+            readOnly
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Supplier</label>
+          <input
+            className="mt-1 w-full rounded border border-slate-300 p-2"
+            value={supplier}
+            onChange={(e) => setSupplier(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Note</label>
+          <textarea
+            className="mt-1 w-full rounded border border-slate-300 p-2"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <h2 className="text-lg font-medium">Line items</h2>
+          <p className="text-xs text-slate-500">
+            Allowed file types on next step: {ALLOWED_ATTACHMENT_TYPES.join(", ")}
+          </p>
+          <div className="mt-2 space-y-2">
+            {lines.map((l, i) => (
+              <div key={i} className="flex gap-2">
+                <input
+                  className="flex-1 rounded border border-slate-300 p-2"
+                  placeholder="Description"
+                  value={l.description}
+                  onChange={(e) => updateLine(i, { description: e.target.value })}
+                />
+                <input
+                  className="w-20 rounded border border-slate-300 p-2"
+                  placeholder="Qty"
+                  value={l.qty}
+                  onChange={(e) => updateLine(i, { qty: e.target.value })}
+                />
+                <input
+                  className="w-32 rounded border border-slate-300 p-2"
+                  placeholder="Unit ₱"
+                  value={l.unit_price_pesos}
+                  onChange={(e) => updateLine(i, { unit_price_pesos: e.target.value })}
+                />
+                <button type="button" onClick={() => removeLine(i)} className="text-sm">
+                  remove
+                </button>
+              </div>
+            ))}
+          </div>
+          <button type="button" onClick={addLine} className="mt-2 text-sm underline">
+            + add line
+          </button>
+          <p className="mt-2 text-sm">Total: {centavosToPeso(totalCentavos)}</p>
+        </div>
+
+        {err && <p className="text-sm text-red-600">{err}</p>}
+        <button
+          type="submit"
+          disabled={busy || !workspaceId || !projectId}
+          className="rounded bg-slate-900 px-4 py-2 text-sm text-white disabled:opacity-50"
+        >
+          {busy ? "Creating..." : "Create draft"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/lib/po/money.ts
+++ b/src/lib/po/money.ts
@@ -1,0 +1,24 @@
+/**
+ * Centavo helpers (ADR-4). Local copy; will be deduped post-merge with
+ * src/lib/money.ts (added by issue #3).
+ */
+
+export function lineTotalCentavos(qty: number, unitPriceCentavos: number): number {
+  if (!Number.isFinite(qty) || qty < 0) throw new Error("qty must be >= 0");
+  if (!Number.isInteger(unitPriceCentavos) || unitPriceCentavos < 0)
+    throw new Error("unit_price_centavos must be a non-negative integer");
+  // qty may have up to 3 decimals; round to nearest centavo.
+  return Math.round(qty * unitPriceCentavos);
+}
+
+export function sumCentavos(values: number[]): number {
+  return values.reduce((a, b) => a + b, 0);
+}
+
+export function centavosToPeso(c: number): string {
+  const sign = c < 0 ? "-" : "";
+  const abs = Math.abs(c);
+  const pesos = Math.floor(abs / 100);
+  const cents = abs % 100;
+  return `${sign}₱${pesos.toLocaleString("en-PH")}.${cents.toString().padStart(2, "0")}`;
+}

--- a/src/lib/po/state-machine.ts
+++ b/src/lib/po/state-machine.ts
@@ -1,0 +1,37 @@
+/**
+ * Purchase Order state machine.
+ *
+ *   [null] --create--> draft --submit--> pending --approve--> approved
+ *                                                  \--reject--> rejected
+ *
+ * Edits are only allowed in `draft`. Rejected POs cannot be re-submitted —
+ * the PM clones into a new draft instead. No backwards transitions.
+ */
+
+export type POStatus = "draft" | "pending" | "approved" | "rejected";
+export type POAction = "create" | "submit" | "approve" | "reject";
+
+export type TransitionResult =
+  | { ok: true; to: POStatus }
+  | { ok: false; error: string };
+
+export function transition(
+  from: POStatus | null,
+  action: POAction,
+): TransitionResult {
+  if (from === null && action === "create") return { ok: true, to: "draft" };
+  if (from === "draft" && action === "submit") return { ok: true, to: "pending" };
+  if (from === "pending" && action === "approve")
+    return { ok: true, to: "approved" };
+  if (from === "pending" && action === "reject")
+    return { ok: true, to: "rejected" };
+
+  return {
+    ok: false,
+    error: `Illegal transition: ${from ?? "null"} --${action}-->`,
+  };
+}
+
+export function canEdit(status: POStatus): boolean {
+  return status === "draft";
+}

--- a/src/lib/po/types.ts
+++ b/src/lib/po/types.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const LineItemInput = z.object({
+  description: z.string().min(1).max(500),
+  qty: z.number().nonnegative(),
+  unit_price_centavos: z.number().int().nonnegative(),
+});
+
+export const CreatePOInput = z.object({
+  workspace_id: z.string().uuid(),
+  project_id: z.string().uuid(),
+  supplier_name: z.string().min(1).max(200),
+  note: z.string().max(2000).optional().nullable(),
+  line_items: z.array(LineItemInput).default([]),
+});
+
+export const UpdatePOInput = z.object({
+  supplier_name: z.string().min(1).max(200).optional(),
+  note: z.string().max(2000).nullable().optional(),
+  line_items: z.array(LineItemInput).optional(),
+});
+
+export const ALLOWED_ATTACHMENT_TYPES = [
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+] as const;
+export type AllowedAttachmentType = (typeof ALLOWED_ATTACHMENT_TYPES)[number];

--- a/supabase/migrations/20260430200100_e3_purchase_orders.sql
+++ b/supabase/migrations/20260430200100_e3_purchase_orders.sql
@@ -1,0 +1,287 @@
+-- E3: Purchase Orders + line items + attachments + status history
+-- ADR-4: money stored in centavos (bigint).
+-- ADR-5: per-workspace PO sequence reserved at submit.
+-- ADR-6: RLS scoped via auth.user_workspace_ids() (defined in e1).
+
+-- ---------------------------------------------------------------------------
+-- Enums
+-- ---------------------------------------------------------------------------
+do $$ begin
+  create type po_status as enum ('draft', 'pending', 'approved', 'rejected');
+exception when duplicate_object then null; end $$;
+
+-- ---------------------------------------------------------------------------
+-- Tables
+-- ---------------------------------------------------------------------------
+create table if not exists public.purchase_orders (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references public.workspaces(id) on delete cascade,
+  project_id uuid not null references public.projects(id) on delete restrict,
+  po_number text,
+  supplier_name text not null,
+  total_centavos bigint not null default 0,
+  note text,
+  status po_status not null default 'draft',
+  created_by uuid not null references auth.users(id) on delete restrict,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  submitted_at timestamptz,
+  decided_by uuid references auth.users(id),
+  decided_at timestamptz,
+  decision_note text,
+  unique (workspace_id, po_number)
+);
+
+create index if not exists purchase_orders_workspace_idx on public.purchase_orders(workspace_id);
+create index if not exists purchase_orders_project_idx on public.purchase_orders(project_id);
+create index if not exists purchase_orders_created_by_idx on public.purchase_orders(created_by);
+create index if not exists purchase_orders_status_idx on public.purchase_orders(status);
+
+create table if not exists public.po_line_items (
+  id uuid primary key default gen_random_uuid(),
+  po_id uuid not null references public.purchase_orders(id) on delete cascade,
+  description text not null,
+  qty numeric(14, 3) not null check (qty >= 0),
+  unit_price_centavos bigint not null check (unit_price_centavos >= 0),
+  line_total_centavos bigint not null check (line_total_centavos >= 0),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists po_line_items_po_idx on public.po_line_items(po_id);
+
+create table if not exists public.po_attachments (
+  id uuid primary key default gen_random_uuid(),
+  po_id uuid not null references public.purchase_orders(id) on delete cascade,
+  storage_path text not null,
+  filename text not null,
+  content_type text not null,
+  size_bytes bigint not null check (size_bytes >= 0),
+  uploaded_by uuid not null references auth.users(id) on delete restrict,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists po_attachments_po_idx on public.po_attachments(po_id);
+
+create table if not exists public.po_status_history (
+  id uuid primary key default gen_random_uuid(),
+  po_id uuid not null references public.purchase_orders(id) on delete cascade,
+  from_status po_status,
+  to_status po_status not null,
+  actor_id uuid not null references auth.users(id) on delete restrict,
+  note text,
+  at timestamptz not null default now()
+);
+
+create index if not exists po_status_history_po_idx on public.po_status_history(po_id);
+
+-- ---------------------------------------------------------------------------
+-- Per-workspace PO counter (ADR-5)
+-- ---------------------------------------------------------------------------
+create table if not exists public.workspace_po_counters (
+  workspace_id uuid primary key references public.workspaces(id) on delete cascade,
+  last_number bigint not null default 0
+);
+
+create or replace function public.next_po_number(p_workspace_id uuid)
+returns text
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  n bigint;
+begin
+  insert into public.workspace_po_counters (workspace_id, last_number)
+  values (p_workspace_id, 1)
+  on conflict (workspace_id)
+    do update set last_number = public.workspace_po_counters.last_number + 1
+  returning last_number into n;
+
+  return 'PO-' || lpad(n::text, 3, '0');
+end;
+$$;
+
+revoke all on function public.next_po_number(uuid) from public;
+grant execute on function public.next_po_number(uuid) to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- RLS
+-- ---------------------------------------------------------------------------
+alter table public.purchase_orders enable row level security;
+alter table public.po_line_items enable row level security;
+alter table public.po_attachments enable row level security;
+alter table public.po_status_history enable row level security;
+alter table public.workspace_po_counters enable row level security;
+
+-- Helper: is current user owner of given workspace?
+create or replace function public.is_workspace_owner(p_workspace_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from public.memberships m
+    where m.workspace_id = p_workspace_id
+      and m.user_id = auth.uid()
+      and m.role = 'owner'
+      and m.status = 'active'
+  );
+$$;
+
+grant execute on function public.is_workspace_owner(uuid) to authenticated;
+
+-- purchase_orders SELECT:
+--   * owners: any PO in their workspace
+--   * other members (pm/bookkeeper): only POs they created
+--   (project-assignment scoping is a future refinement; for sprint-01 keep
+--    rules simple — PMs see their own, owners see all.)
+drop policy if exists "po_select" on public.purchase_orders;
+create policy "po_select" on public.purchase_orders
+  for select using (
+    workspace_id in (select auth.user_workspace_ids())
+    and (
+      public.is_workspace_owner(workspace_id)
+      or created_by = auth.uid()
+    )
+  );
+
+-- INSERT: must be a member of the workspace, must be pm or owner, draft only,
+-- created_by must be self.
+drop policy if exists "po_insert_pm" on public.purchase_orders;
+create policy "po_insert_pm" on public.purchase_orders
+  for insert with check (
+    workspace_id in (select auth.user_workspace_ids())
+    and created_by = auth.uid()
+    and status = 'draft'
+    and exists (
+      select 1 from public.memberships m
+      where m.workspace_id = purchase_orders.workspace_id
+        and m.user_id = auth.uid()
+        and m.role in ('pm', 'owner')
+        and m.status = 'active'
+    )
+  );
+
+-- UPDATE: PM owner of a draft can update; owner of workspace can update
+-- (e.g. for approve/reject in issue #5).
+drop policy if exists "po_update" on public.purchase_orders;
+create policy "po_update" on public.purchase_orders
+  for update using (
+    workspace_id in (select auth.user_workspace_ids())
+    and (
+      public.is_workspace_owner(workspace_id)
+      or (created_by = auth.uid() and status = 'draft')
+    )
+  );
+
+-- po_line_items: scoped via parent PO.
+drop policy if exists "poli_select" on public.po_line_items;
+create policy "poli_select" on public.po_line_items
+  for select using (
+    exists (
+      select 1 from public.purchase_orders po
+      where po.id = po_line_items.po_id
+        and po.workspace_id in (select auth.user_workspace_ids())
+        and (public.is_workspace_owner(po.workspace_id) or po.created_by = auth.uid())
+    )
+  );
+
+drop policy if exists "poli_write_owner_draft" on public.po_line_items;
+create policy "poli_write_owner_draft" on public.po_line_items
+  for all using (
+    exists (
+      select 1 from public.purchase_orders po
+      where po.id = po_line_items.po_id
+        and po.created_by = auth.uid()
+        and po.status = 'draft'
+    )
+  ) with check (
+    exists (
+      select 1 from public.purchase_orders po
+      where po.id = po_line_items.po_id
+        and po.created_by = auth.uid()
+        and po.status = 'draft'
+    )
+  );
+
+-- po_attachments: select scoped via parent PO; insert by creator on draft.
+drop policy if exists "poa_select" on public.po_attachments;
+create policy "poa_select" on public.po_attachments
+  for select using (
+    exists (
+      select 1 from public.purchase_orders po
+      where po.id = po_attachments.po_id
+        and po.workspace_id in (select auth.user_workspace_ids())
+        and (public.is_workspace_owner(po.workspace_id) or po.created_by = auth.uid())
+    )
+  );
+
+drop policy if exists "poa_insert_owner_draft" on public.po_attachments;
+create policy "poa_insert_owner_draft" on public.po_attachments
+  for insert with check (
+    uploaded_by = auth.uid()
+    and exists (
+      select 1 from public.purchase_orders po
+      where po.id = po_attachments.po_id
+        and po.created_by = auth.uid()
+        and po.status = 'draft'
+    )
+  );
+
+drop policy if exists "poa_delete_owner_draft" on public.po_attachments;
+create policy "poa_delete_owner_draft" on public.po_attachments
+  for delete using (
+    exists (
+      select 1 from public.purchase_orders po
+      where po.id = po_attachments.po_id
+        and po.created_by = auth.uid()
+        and po.status = 'draft'
+    )
+  );
+
+-- po_status_history: select scoped via parent PO; inserts go through
+-- service-role / route handlers (no insert policy = denied for anon/auth).
+drop policy if exists "posh_select" on public.po_status_history;
+create policy "posh_select" on public.po_status_history
+  for select using (
+    exists (
+      select 1 from public.purchase_orders po
+      where po.id = po_status_history.po_id
+        and po.workspace_id in (select auth.user_workspace_ids())
+        and (public.is_workspace_owner(po.workspace_id) or po.created_by = auth.uid())
+    )
+  );
+
+-- workspace_po_counters: no direct access; use next_po_number().
+
+-- ---------------------------------------------------------------------------
+-- Storage bucket for PO attachments
+-- ---------------------------------------------------------------------------
+insert into storage.buckets (id, name, public)
+values ('po-attachments', 'po-attachments', false)
+on conflict (id) do nothing;
+
+-- Path layout: <workspace_id>/<po_id>/<filename>
+-- Read: any workspace member.
+drop policy if exists "po_attachments_read" on storage.objects;
+create policy "po_attachments_read" on storage.objects
+  for select using (
+    bucket_id = 'po-attachments'
+    and (storage.foldername(name))[1]::uuid in (select auth.user_workspace_ids())
+  );
+
+-- Write: only PM/owner who owns the draft PO referenced by the second path segment.
+drop policy if exists "po_attachments_write_owner_draft" on storage.objects;
+create policy "po_attachments_write_owner_draft" on storage.objects
+  for insert with check (
+    bucket_id = 'po-attachments'
+    and exists (
+      select 1 from public.purchase_orders po
+      where po.id::text = (storage.foldername(name))[2]
+        and po.workspace_id::text = (storage.foldername(name))[1]
+        and po.created_by = auth.uid()
+        and po.status = 'draft'
+    )
+  );

--- a/tests/unit/po-money.test.ts
+++ b/tests/unit/po-money.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { lineTotalCentavos, sumCentavos, centavosToPeso } from "@/lib/po/money";
+
+describe("PO money helpers", () => {
+  it("lineTotalCentavos multiplies and rounds", () => {
+    expect(lineTotalCentavos(2, 12345)).toBe(24690);
+    expect(lineTotalCentavos(1.5, 100)).toBe(150);
+    expect(lineTotalCentavos(0.333, 10000)).toBe(3330);
+  });
+
+  it("lineTotalCentavos rounds to nearest centavo", () => {
+    // 0.1 * 333 = 33.3 → 33
+    expect(lineTotalCentavos(0.1, 333)).toBe(33);
+    // 0.5 * 333 = 166.5 → 167 (round half up via Math.round)
+    expect(lineTotalCentavos(0.5, 333)).toBe(167);
+  });
+
+  it("rejects negatives", () => {
+    expect(() => lineTotalCentavos(-1, 100)).toThrow();
+    expect(() => lineTotalCentavos(1, -1)).toThrow();
+  });
+
+  it("sumCentavos", () => {
+    expect(sumCentavos([])).toBe(0);
+    expect(sumCentavos([100, 200, 50])).toBe(350);
+  });
+
+  it("centavosToPeso formats", () => {
+    expect(centavosToPeso(0)).toBe("₱0.00");
+    expect(centavosToPeso(150)).toBe("₱1.50");
+    expect(centavosToPeso(123456)).toBe("₱1,234.56");
+    expect(centavosToPeso(-150)).toBe("-₱1.50");
+  });
+});

--- a/tests/unit/po-state-machine.test.ts
+++ b/tests/unit/po-state-machine.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { transition, canEdit, type POStatus, type POAction } from "@/lib/po/state-machine";
+
+describe("PO state machine", () => {
+  it("null --create--> draft", () => {
+    expect(transition(null, "create")).toEqual({ ok: true, to: "draft" });
+  });
+
+  it("draft --submit--> pending", () => {
+    expect(transition("draft", "submit")).toEqual({ ok: true, to: "pending" });
+  });
+
+  it("pending --approve--> approved", () => {
+    expect(transition("pending", "approve")).toEqual({ ok: true, to: "approved" });
+  });
+
+  it("pending --reject--> rejected", () => {
+    expect(transition("pending", "reject")).toEqual({ ok: true, to: "rejected" });
+  });
+
+  const illegal: Array<[POStatus | null, POAction]> = [
+    [null, "submit"],
+    [null, "approve"],
+    [null, "reject"],
+    ["draft", "create"],
+    ["draft", "approve"],
+    ["draft", "reject"],
+    ["pending", "create"],
+    ["pending", "submit"],
+    ["approved", "create"],
+    ["approved", "submit"],
+    ["approved", "approve"],
+    ["approved", "reject"],
+    ["rejected", "create"],
+    ["rejected", "submit"],
+    ["rejected", "approve"],
+    ["rejected", "reject"],
+  ];
+
+  it.each(illegal)("rejects illegal transition %s --%s-->", (from, action) => {
+    const r = transition(from, action);
+    expect(r.ok).toBe(false);
+  });
+
+  it("canEdit only true for draft", () => {
+    expect(canEdit("draft")).toBe(true);
+    expect(canEdit("pending")).toBe(false);
+    expect(canEdit("approved")).toBe(false);
+    expect(canEdit("rejected")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds E3 purchase order CRUD, state machine, line items, attachments, and per-workspace PO sequence (ADR-5).
- Migration `20260430200100_e3_purchase_orders.sql` creates `purchase_orders`, `po_line_items`, `po_attachments`, `po_status_history`, `workspace_po_counters`, the `next_po_number(workspace_id)` RPC, RLS policies, and the `po-attachments` storage bucket with path-prefix policies.
- State machine (`src/lib/po/state-machine.ts`) covers `null->draft->pending->{approved,rejected}` with full vitest coverage of every legal and illegal transition. Edits gated to `draft` in route handlers and via RLS.
- Routes: `GET/POST /api/pos`, `GET/PATCH /api/pos/:id`, `POST /api/pos/:id/submit` (reserves `PO-NNN` via service-role RPC and writes `po_status_history`), and the signed-URL attachment flow (`/attachments/sign` + `/attachments`) with content-type allowlist (PDF, PNG, JPEG, WEBP).
- Minimal UI: `/pos/new?projectId=...` and `/pos/[id]`.

## Non-obvious decisions
- **PO number sequence**: `workspace_po_counters` row-per-workspace with `INSERT ... ON CONFLICT DO UPDATE ... RETURNING last_number` for atomic increment. Reserved at submit, not draft. Function is `SECURITY DEFINER`; called via service-role from the submit route after the route validates ownership.
- **Draft-edit gating**: enforced at three layers — RLS UPDATE policy (`created_by = auth.uid() AND status = 'draft'`), route handler `canEdit()` check, and a `409 Conflict` response when violated.
- **Status history inserts** go through the service-role client because RLS denies direct inserts (immutable audit log). Workspace member SELECT is allowed.
- **Storage RLS** uses `storage.foldername(name)[1]` (workspace_id) and `[2]` (po_id) for path-prefix scoping.
- **`centavosToPeso` / line-total math**: local copy in `src/lib/po/money.ts` per the parallel-agent guidance — duplicates the helper issue #3 will add to `src/lib/money.ts`; deduped post-merge.

## Dependencies / conflicts
- Depends on issue #3's `projects` table (foreign key to `projects(id)`); migration prefix `20260430200100` runs after #3's `20260430200000`.
- Approve/reject routes intentionally not implemented (issue #5).
- No edits to e1/e2 files; reuses `auth.user_workspace_ids()`.

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 34 unit tests pass (state machine + money + existing)
- [x] `pnpm build` — succeeds
- [ ] Apply migration in Supabase local; verify RLS denies cross-workspace reads
- [ ] Manual: PM creates draft, uploads attachment, submits, confirms `PO-001`