### PR TITLE
chore(e6): e2e golden path + demo seed + staging deploy docs (closes #7)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,3 +12,8 @@ NEXT_PUBLIC_SENTRY_DSN=
 
 # Public app URL — used for invite-accept links when the request has no Origin.
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Dev-only: shared secret guarding /api/test-only/last-invite (used by Playwright
+# golden path to read invite tokens without an email round-trip). Disabled
+# entirely when NODE_ENV=production. Pick anything for local dev.
+TEST_INVITE_SECRET=test-invite-secret

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,82 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# This job is expected to fail until issues #3-#6 land (signup, invites,
+# projects, POs, dashboards). To temporarily skip while those are in flight,
+# set the repo variable `E2E_ENABLED` to "false" — the gate below will short-
+# circuit the job. Flip it back to "true" once #3-#6 are merged.
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    # Allow the workflow to keep going while features land. Flip to `false`
+    # once the golden path is reliably green.
+    continue-on-error: true
+    if: ${{ vars.E2E_ENABLED != 'false' }}
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Local Supabase stack values — replaced by `supabase start` once we
+      # add it. For now point at the Postgres service container; seed/test
+      # steps below will skip gracefully if Supabase isn't running.
+      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon
+      SUPABASE_SERVICE_ROLE_KEY: placeholder-service-role
+      TEST_INVITE_SECRET: test-invite-secret
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Supabase CLI
+        run: |
+          curl -L https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz \
+            | tar xz -C /usr/local/bin supabase || true
+          supabase --version || echo "supabase CLI not available; skipping local stack"
+
+      - name: Start Supabase local stack
+        run: supabase start || echo "supabase start failed; e2e will be skipped downstream"
+
+      - name: Apply migrations
+        run: supabase db reset --no-seed || echo "migrations skipped"
+
+      - name: Run seed
+        run: pnpm seed || echo "seed skipped (depends on #3-#6 tables)"
+
+      - name: Install Playwright
+        run: pnpm playwright install --with-deps chromium
+
+      - name: Run Playwright E2E
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,0 +1,111 @@
+# purchaseer
+
+Make every construction project profitable on purpose, not by accident — by giving owners the visibility to act before the money is gone. purchaseer is a mobile-first purchasing platform that turns every Request Slip, Purchase Order, and Liquidation into real-time project-level visibility, purpose-built for the local Request Slip → PO → Liquidation workflow used by small-to-mid construction firms in the Philippines and Latin America.
+
+See [`PRODUCT-PROFILE.md`](./PRODUCT-PROFILE.md) for full product context and [`.chalk/sprint-01/PLAN.md`](./.chalk/sprint-01/PLAN.md) for the sprint-01 technical plan.
+
+## Stack
+
+- Next.js 15 (App Router) + React 19 + TypeScript + Tailwind
+- Supabase (Postgres + Auth + Storage)
+- Resend (transactional email)
+- Sentry (errors)
+- Vitest (unit), Playwright (E2E)
+
+## Local development
+
+Prerequisites:
+
+- Node 22+
+- [pnpm](https://pnpm.io/) 10+
+- [Supabase CLI](https://supabase.com/docs/guides/cli) (for the local Postgres + Auth stack)
+- Docker (Supabase CLI uses it under the hood)
+
+```bash
+# 1. Install deps
+pnpm install
+
+# 2. Copy env template
+cp .env.local.example .env.local
+# fill in the Supabase values printed by `supabase start` below
+
+# 3. Start the local Supabase stack (Postgres, Auth, Storage on :54321)
+supabase start
+
+# 4. Apply migrations
+supabase db reset
+
+# 5. Seed the demo workspace (idempotent)
+pnpm seed
+# pass --reset to wipe demo-workspace rows before re-seeding:
+pnpm seed -- --reset
+
+# 6. Run the dev server
+pnpm dev
+# -> http://localhost:3000
+```
+
+The seed script prints generated passwords for `owner@purchaseer.dev` and `pm@purchaseer.dev` to stdout. Re-running the seed rotates the passwords (idempotent).
+
+### Environment variables
+
+See [`.env.local.example`](./.env.local.example). Key vars:
+
+| Var | Used for |
+|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Browser + server Supabase clients |
+| `SUPABASE_SERVICE_ROLE_KEY` | Seed script + server-only admin tasks (never ship to browser) |
+| `RESEND_API_KEY` | Invite + approval emails |
+| `TEST_INVITE_SECRET` | Dev-only `/api/test-only/last-invite` endpoint used by the Playwright golden path |
+| `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` | Error reporting (leave blank to disable) |
+
+## Tests
+
+```bash
+pnpm lint          # eslint
+pnpm test          # vitest unit + integration
+pnpm test:e2e      # playwright golden path (mobile viewport)
+pnpm build         # next build
+```
+
+The E2E suite runs against the local dev server on a 390x844 (iPhone 14) viewport and exercises the full signup → invite → project → PO → approval → dashboard refresh path. It depends on the dev-only `/api/test-only/last-invite` endpoint — disabled when `NODE_ENV=production` and additionally gated by the `x-test-secret` header.
+
+## Deploy (Vercel staging)
+
+A `vercel.json` is checked in with framework + region pinning. Credentials are not configured in this repo; deploy is a manual operator step:
+
+```bash
+# One-time
+pnpm dlx vercel link
+
+# Push environment variables to Vercel (or set via dashboard):
+pnpm dlx vercel env add NEXT_PUBLIC_SUPABASE_URL preview
+pnpm dlx vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY preview
+pnpm dlx vercel env add SUPABASE_SERVICE_ROLE_KEY preview
+pnpm dlx vercel env add RESEND_API_KEY preview
+pnpm dlx vercel env add SENTRY_DSN preview
+
+# Deploy a preview build
+pnpm build
+pnpm dlx vercel deploy --prebuilt
+```
+
+Point preview deploys at a Supabase **staging** project (separate from prod). Migrations should be applied with `supabase db push` against the staging project before promoting a deploy. Manual smoke on a real phone over LTE is required before sign-off — see `.chalk/sprint-01/PLAN.md`.
+
+## Layout
+
+```
+src/
+  app/            Next.js App Router (pages, route handlers)
+    api/_test/    Dev-only endpoints (gated; 404 in prod)
+  lib/            Supabase clients, auth, email, rate limit
+  middleware.ts   Auth + workspace scoping
+supabase/
+  migrations/     SQL migrations (Supabase CLI)
+scripts/
+  seed.ts         Demo seed (pnpm seed)
+tests/
+  unit/           Vitest unit tests
+  integration/    Vitest integration (RLS, route handlers)
+  e2e/            Playwright golden path
+```

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "seed": "tsx scripts/seed.ts"
   },
   "dependencies": {
     "@sentry/nextjs": "^8.45.0",
@@ -35,6 +36,7 @@
     "jsdom": "^25.0.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,14 +9,25 @@ export default defineConfig({
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",
+    // Mobile-first: iPhone 14 viewport. Spec-level use() can override.
+    viewport: { width: 390, height: 844 },
   },
   projects: [
-    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    {
+      name: "mobile-chromium",
+      use: {
+        ...devices["Pixel 7"],
+        viewport: { width: 390, height: 844 },
+      },
+    },
   ],
   webServer: {
     command: "pnpm dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    env: {
+      TEST_INVITE_SECRET: process.env.TEST_INVITE_SECRET ?? "test-invite-secret",
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,10 @@ importers:
         version: 8.5.12
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19
+        version: 3.4.19(tsx@4.21.0)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -211,9 +214,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -223,9 +238,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -235,9 +262,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -247,9 +286,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -259,9 +310,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -271,9 +334,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -283,9 +358,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -295,9 +382,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -307,11 +406,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -319,9 +442,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -331,15 +472,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1904,6 +2063,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3217,6 +3381,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3616,70 +3785,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
@@ -5422,6 +5669,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -6358,12 +6634,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.12
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.12):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.12)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.12
+      tsx: 4.21.0
 
   postcss-nested@6.2.0(postcss@8.5.12):
     dependencies:
@@ -6789,7 +7066,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.21.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -6808,7 +7085,7 @@ snapshots:
       postcss: 8.5.12
       postcss-import: 15.1.0(postcss@8.5.12)
       postcss-js: 4.1.0(postcss@8.5.12)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.12)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.12)(tsx@4.21.0)
       postcss-nested: 6.2.0(postcss@8.5.12)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -6891,6 +7168,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,316 @@
+/* eslint-disable no-console */
+/**
+ * Demo seed script.
+ *
+ * Creates a single demo workspace with:
+ *   - 1 Owner (owner@purchaseer.dev)
+ *   - 1 PM    (pm@purchaseer.dev)
+ *   - 3 projects with varied budgets
+ *   - 5 POs across statuses (draft, pending, approved, rejected, approved)
+ *
+ * Idempotent: re-running upserts users + workspace and tops the demo back up.
+ * `--reset` truncates demo-workspace-scoped rows (NOT global) before seeding.
+ *
+ * Uses the SERVICE-ROLE client to bypass RLS. Server-only — never ship this key.
+ *
+ * Run: pnpm seed             (idempotent top-up)
+ *      pnpm seed -- --reset  (wipe demo workspace rows, then seed fresh)
+ *
+ * NOTE: This script targets tables/columns described in `.chalk/sprint-01/PLAN.md`.
+ * Until issues #3–#6 land, several of these tables won't exist yet and the script
+ * will fail on first run — that's expected.
+ */
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { randomBytes } from "node:crypto";
+
+const DEMO_WORKSPACE_NAME = "Purchaseer Demo Co.";
+const OWNER_EMAIL = "owner@purchaseer.dev";
+const PM_EMAIL = "pm@purchaseer.dev";
+
+type SeedSupabase = SupabaseClient;
+
+function generatePassword(): string {
+  // 18 url-safe chars; printed once to stdout for the operator.
+  return randomBytes(14).toString("base64url");
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function makeClient(): SeedSupabase {
+  return createClient(
+    requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+async function ensureUser(
+  client: SeedSupabase,
+  email: string,
+): Promise<{ id: string; password: string }> {
+  // List all users (small in dev), find by email; otherwise create.
+  // admin.listUsers paginates — for the demo workspace one page is enough.
+  const { data: list, error: listErr } = await client.auth.admin.listUsers({
+    page: 1,
+    perPage: 200,
+  });
+  if (listErr) throw listErr;
+
+  const existing = list.users.find(
+    (u) => u.email?.toLowerCase() === email.toLowerCase(),
+  );
+  if (existing) {
+    // Rotate password so the operator can log in with the printed creds.
+    const password = generatePassword();
+    const { error: updErr } = await client.auth.admin.updateUserById(
+      existing.id,
+      { password, email_confirm: true },
+    );
+    if (updErr) throw updErr;
+    return { id: existing.id, password };
+  }
+
+  const password = generatePassword();
+  const { data: created, error: createErr } =
+    await client.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    });
+  if (createErr) throw createErr;
+  return { id: created.user.id, password };
+}
+
+async function ensureWorkspace(
+  client: SeedSupabase,
+  name: string,
+): Promise<string> {
+  const { data: existing, error: selErr } = await client
+    .from("workspaces")
+    .select("id")
+    .eq("name", name)
+    .maybeSingle();
+  if (selErr) throw selErr;
+  if (existing) return existing.id as string;
+
+  const { data: inserted, error: insErr } = await client
+    .from("workspaces")
+    .insert({ name })
+    .select("id")
+    .single();
+  if (insErr) throw insErr;
+  return inserted.id as string;
+}
+
+async function ensureMembership(
+  client: SeedSupabase,
+  workspaceId: string,
+  userId: string,
+  role: "owner" | "pm" | "bookkeeper",
+) {
+  const { error } = await client.from("memberships").upsert(
+    {
+      workspace_id: workspaceId,
+      user_id: userId,
+      role,
+      status: "active",
+    },
+    { onConflict: "workspace_id,user_id" },
+  );
+  if (error) throw error;
+}
+
+async function resetWorkspace(client: SeedSupabase, workspaceId: string) {
+  // Delete in FK-safe order. Scoped to the demo workspace ONLY.
+  const childTables = [
+    "po_status_history",
+    "po_attachments",
+    "po_line_items",
+  ];
+  for (const t of childTables) {
+    // These tables don't have workspace_id directly; cascade-via-PO is fine
+    // once purchase_orders rows are deleted below. We rely on FK ON DELETE CASCADE.
+  }
+  const scopedTables = [
+    "purchase_orders",
+    "rs_status_history",
+    "rs_line_items",
+    "request_slips",
+    "project_budget_history",
+    "projects",
+    "invites",
+    "notifications",
+  ];
+  for (const t of scopedTables) {
+    const { error } = await client
+      .from(t)
+      .delete()
+      .eq("workspace_id", workspaceId);
+    if (error && !`${error.message}`.includes("does not exist")) {
+      console.warn(`reset: skipping ${t} — ${error.message}`);
+    }
+  }
+  // Memberships are kept so user logins still resolve into the workspace.
+}
+
+async function seedProjects(
+  client: SeedSupabase,
+  workspaceId: string,
+  ownerId: string,
+  pmId: string,
+): Promise<string[]> {
+  const projects = [
+    { name: "Quezon City Townhouse — Phase 1", budget_centavos: 350_000_00 },
+    { name: "Makati Office Fit-Out", budget_centavos: 1_200_000_00 },
+    { name: "Cebu Warehouse Renovation", budget_centavos: 2_500_000_00 },
+  ];
+
+  const ids: string[] = [];
+  for (const p of projects) {
+    const { data, error } = await client
+      .from("projects")
+      .upsert(
+        {
+          workspace_id: workspaceId,
+          name: p.name,
+          budget_centavos: p.budget_centavos,
+          assigned_pm_id: pmId,
+          status: "active",
+          created_by: ownerId,
+        },
+        { onConflict: "workspace_id,name" },
+      )
+      .select("id")
+      .single();
+    if (error) throw error;
+    ids.push(data.id as string);
+  }
+  return ids;
+}
+
+async function seedPurchaseOrders(
+  client: SeedSupabase,
+  workspaceId: string,
+  projectIds: string[],
+  ownerId: string,
+  pmId: string,
+) {
+  // 5 POs across statuses: draft, pending, approved, rejected, approved.
+  const specs = [
+    {
+      status: "draft" as const,
+      project: projectIds[0],
+      supplier: "ACME Hardware",
+      lines: [{ description: "Cement (40kg)", qty: 50, unit_price_centavos: 250_00 }],
+    },
+    {
+      status: "pending" as const,
+      project: projectIds[0],
+      supplier: "BuildRight Supplies",
+      lines: [{ description: "Rebar 10mm", qty: 200, unit_price_centavos: 180_00 }],
+    },
+    {
+      status: "approved" as const,
+      project: projectIds[1],
+      supplier: "Metro Tiles",
+      lines: [{ description: "Porcelain tile 60x60", qty: 120, unit_price_centavos: 320_00 }],
+    },
+    {
+      status: "rejected" as const,
+      project: projectIds[1],
+      supplier: "QuickShip Co.",
+      lines: [{ description: "Express delivery surcharge", qty: 1, unit_price_centavos: 25_000_00 }],
+    },
+    {
+      status: "approved" as const,
+      project: projectIds[2],
+      supplier: "Northern Steel",
+      lines: [{ description: "I-beam 6m", qty: 8, unit_price_centavos: 12_500_00 }],
+    },
+  ];
+
+  for (let i = 0; i < specs.length; i++) {
+    const s = specs[i];
+    const total = s.lines.reduce(
+      (sum, l) => sum + l.qty * l.unit_price_centavos,
+      0,
+    );
+    const submitted = s.status !== "draft";
+    const decided = s.status === "approved" || s.status === "rejected";
+
+    const { data: po, error: poErr } = await client
+      .from("purchase_orders")
+      .insert({
+        workspace_id: workspaceId,
+        project_id: s.project,
+        po_number: `PO-${String(i + 1).padStart(3, "0")}`,
+        supplier_name: s.supplier,
+        total_centavos: total,
+        status: s.status,
+        created_by: pmId,
+        submitted_at: submitted ? new Date().toISOString() : null,
+        decided_by: decided ? ownerId : null,
+        decided_at: decided ? new Date().toISOString() : null,
+        decision_note: s.status === "rejected" ? "Out of scope" : null,
+      })
+      .select("id")
+      .single();
+    if (poErr) throw poErr;
+
+    const lineRows = s.lines.map((l) => ({
+      po_id: po.id as string,
+      description: l.description,
+      qty: l.qty,
+      unit_price_centavos: l.unit_price_centavos,
+      line_total_centavos: l.qty * l.unit_price_centavos,
+    }));
+    const { error: linesErr } = await client
+      .from("po_line_items")
+      .insert(lineRows);
+    if (linesErr) throw linesErr;
+  }
+}
+
+async function main() {
+  const reset = process.argv.includes("--reset");
+  const client = makeClient();
+
+  console.log(`> seeding demo workspace (reset=${reset})`);
+
+  const owner = await ensureUser(client, OWNER_EMAIL);
+  const pm = await ensureUser(client, PM_EMAIL);
+  const workspaceId = await ensureWorkspace(client, DEMO_WORKSPACE_NAME);
+
+  await ensureMembership(client, workspaceId, owner.id, "owner");
+  await ensureMembership(client, workspaceId, pm.id, "pm");
+
+  if (reset) {
+    console.log("> --reset: clearing demo workspace rows");
+    await resetWorkspace(client, workspaceId);
+  }
+
+  const projectIds = await seedProjects(client, workspaceId, owner.id, pm.id);
+  await seedPurchaseOrders(client, workspaceId, projectIds, owner.id, pm.id);
+
+  console.log("");
+  console.log("Demo seed complete.");
+  console.log("---------------------------------------------");
+  console.log(`Workspace : ${DEMO_WORKSPACE_NAME} (${workspaceId})`);
+  console.log(`Owner     : ${OWNER_EMAIL}`);
+  console.log(`            password: ${owner.password}`);
+  console.log(`PM        : ${PM_EMAIL}`);
+  console.log(`            password: ${pm.password}`);
+  console.log("---------------------------------------------");
+}
+
+main().catch((err) => {
+  console.error("seed failed:", err);
+  process.exit(1);
+});

--- a/src/app/api/test-only/last-invite/route.ts
+++ b/src/app/api/test-only/last-invite/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/service-role";
+
+/**
+ * Dev-only endpoint that returns the latest invite for a given email.
+ *
+ * Path note: lives under `/api/test-only/...` rather than `/api/_test/...`
+ * because Next.js treats leading-underscore folders as private and excludes
+ * them from routing.
+ *
+ * Gated by:
+ *   1. NODE_ENV !== "production" — disabled entirely in prod builds
+ *   2. Header `x-test-secret` must equal `process.env.TEST_INVITE_SECRET`
+ *
+ * Used by the Playwright golden path to "simulate accept" without a real
+ * email round-trip.
+ */
+export async function GET(req: Request) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "not found" }, { status: 404 });
+  }
+
+  const secret = process.env.TEST_INVITE_SECRET;
+  if (!secret || req.headers.get("x-test-secret") !== secret) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const email = url.searchParams.get("email");
+  if (!email) {
+    return NextResponse.json({ error: "email required" }, { status: 400 });
+  }
+
+  const supabase = createSupabaseServiceRoleClient();
+  const { data, error } = await supabase
+    .from("invites")
+    .select("id, workspace_id, email, role, token, token_hash, expires_at, accepted_at, created_at")
+    .ilike("email", email)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (!data) {
+    return NextResponse.json({ error: "no invite" }, { status: 404 });
+  }
+  return NextResponse.json({ invite: data });
+}

--- a/tests/e2e/golden-path.spec.ts
+++ b/tests/e2e/golden-path.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Golden path E2E — sprint-01 acceptance test.
+ *
+ *   signup as Owner
+ *   -> invite PM
+ *   -> simulate accept (read invite token via dev-only /api/test-only/last-invite)
+ *   -> PM logs in
+ *   -> Owner creates a project with budget
+ *   -> PM creates a PO with one line item
+ *   -> PM submits PO
+ *   -> Owner approves PO
+ *   -> Company Dashboard shows updated `% used` within 5s (polling cadence)
+ *
+ * Mobile viewport (iPhone 14): 390 x 844.
+ *
+ * NOTE: This spec depends on UI + APIs from issues #3–#6. Until those merge,
+ * selectors here are best-effort against PLAN.md and will fail in CI. That is
+ * expected and called out in the PR body.
+ */
+
+const VIEWPORT = { width: 390, height: 844 };
+const TEST_SECRET = process.env.TEST_INVITE_SECRET ?? "test-invite-secret";
+
+const stamp = Date.now();
+const OWNER_EMAIL = `owner+${stamp}@e2e.purchaseer.dev`;
+const PM_EMAIL = `pm+${stamp}@e2e.purchaseer.dev`;
+const PASSWORD = "Test1234!Test1234!";
+const WORKSPACE_NAME = `E2E Workspace ${stamp}`;
+const PROJECT_NAME = `E2E Project ${stamp}`;
+const PROJECT_BUDGET_PHP = 100_000; // ₱100,000
+
+test.use({ viewport: VIEWPORT });
+
+async function signupOwner(page: Page) {
+  await page.goto("/signup");
+  await page.getByLabel(/workspace/i).fill(WORKSPACE_NAME);
+  await page.getByLabel(/email/i).fill(OWNER_EMAIL);
+  await page.getByLabel(/password/i).fill(PASSWORD);
+  await page.getByRole("button", { name: /sign ?up|create/i }).click();
+  await expect(page).toHaveURL(/\/(dashboard|app|projects)/i, { timeout: 15_000 });
+}
+
+async function invitePm(page: Page) {
+  await page.goto("/app/team");
+  await page.getByRole("button", { name: /invite/i }).click();
+  await page.getByLabel(/email/i).fill(PM_EMAIL);
+  await page.getByLabel(/role/i).selectOption("pm");
+  await page.getByRole("button", { name: /send|invite/i }).click();
+  await expect(page.getByText(/invited|pending/i)).toBeVisible({ timeout: 10_000 });
+}
+
+async function fetchLatestInviteToken(
+  request: Page["request"],
+  email: string,
+): Promise<string> {
+  const res = await request.get(
+    `/api/test-only/last-invite?email=${encodeURIComponent(email)}`,
+    { headers: { "x-test-secret": TEST_SECRET } },
+  );
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  // Endpoint may return either a raw `token` (dev-only) or a hash; we prefer raw.
+  const token: string | undefined = body?.invite?.token;
+  expect(token, "dev-only invite endpoint must return a raw token").toBeTruthy();
+  return token!;
+}
+
+async function acceptInviteAsPm(page: Page, token: string) {
+  await page.goto(`/accept-invite?token=${encodeURIComponent(token)}`);
+  await page.getByLabel(/password/i).fill(PASSWORD);
+  await page.getByRole("button", { name: /accept|create/i }).click();
+  await expect(page).toHaveURL(/\/(dashboard|app|login)/i, { timeout: 15_000 });
+}
+
+async function login(page: Page, email: string, password: string) {
+  await page.goto("/login");
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByRole("button", { name: /log ?in|sign ?in/i }).click();
+  await expect(page).toHaveURL(/\/(dashboard|app)/i, { timeout: 15_000 });
+}
+
+async function ownerCreatesProject(page: Page) {
+  await page.goto("/app/projects/new");
+  await page.getByLabel(/project name|name/i).fill(PROJECT_NAME);
+  await page.getByLabel(/budget/i).fill(String(PROJECT_BUDGET_PHP));
+  // PM dropdown should include the freshly-accepted PM by email.
+  const pmField = page.getByLabel(/assigned pm|pm/i);
+  if (await pmField.isVisible().catch(() => false)) {
+    await pmField.selectOption({ label: PM_EMAIL });
+  }
+  await page.getByRole("button", { name: /create|save/i }).click();
+  await expect(page.getByText(PROJECT_NAME)).toBeVisible({ timeout: 10_000 });
+}
+
+async function pmCreatesAndSubmitsPo(page: Page) {
+  await page.goto("/app/pos/new");
+  // Pick the project we just created.
+  await page.getByLabel(/project/i).selectOption({ label: PROJECT_NAME });
+  await page.getByLabel(/supplier/i).fill("Test Supplier");
+
+  // Single line item: qty 10 @ ₱5,000 = ₱50,000 (50% of ₱100k budget).
+  await page.getByRole("button", { name: /add line|add item/i }).click();
+  await page.getByLabel(/description/i).fill("Test material");
+  await page.getByLabel(/qty|quantity/i).fill("10");
+  await page.getByLabel(/unit price|price/i).fill("5000");
+
+  await page.getByRole("button", { name: /save draft|save/i }).click();
+  await page.getByRole("button", { name: /submit/i }).click();
+  await expect(page.getByText(/pending/i)).toBeVisible({ timeout: 10_000 });
+}
+
+async function ownerApprovesPo(page: Page) {
+  await page.goto("/app/approvals");
+  await page.getByText(/Test Supplier/).first().click();
+  await page.getByRole("button", { name: /approve/i }).click();
+  await expect(page.getByText(/approved/i).first()).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test("golden path: signup -> invite -> approve -> dashboard updates within 5s", async ({
+  browser,
+}) => {
+  const ownerCtx = await browser.newContext({ viewport: VIEWPORT });
+  const pmCtx = await browser.newContext({ viewport: VIEWPORT });
+  const ownerPage = await ownerCtx.newPage();
+  const pmPage = await pmCtx.newPage();
+
+  try {
+    await signupOwner(ownerPage);
+    await invitePm(ownerPage);
+
+    const token = await fetchLatestInviteToken(ownerPage.request, PM_EMAIL);
+    await acceptInviteAsPm(pmPage, token);
+    await login(pmPage, PM_EMAIL, PASSWORD);
+
+    await ownerCreatesProject(ownerPage);
+    await pmCreatesAndSubmitsPo(pmPage);
+    await ownerApprovesPo(ownerPage);
+
+    // Owner's Company Dashboard should reflect the new approved PO within 5s
+    // (the polling cadence). Use toPass to retry the assertion through one
+    // poll cycle without forcing a manual reload.
+    await ownerPage.goto("/app/dashboard");
+    await expect(async () => {
+      const text = await ownerPage
+        .getByTestId("project-row")
+        .filter({ hasText: PROJECT_NAME })
+        .first()
+        .textContent();
+      // ₱50,000 of ₱100,000 -> 50% used.
+      expect(text ?? "").toMatch(/50\s*%/);
+    }).toPass({ timeout: 5_500, intervals: [500, 1000, 2000] });
+  } finally {
+    await ownerCtx.close();
+    await pmCtx.close();
+  }
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "pnpm build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "devCommand": "pnpm dev",
+  "regions": ["sin1"]
+}


### PR DESCRIPTION
Depends on #3, #4, #5, #6 — green after they merge and this rebases.

Closes #7.

## Summary
- `scripts/seed.ts` — idempotent demo seed (Owner + PM + 3 projects + 5 POs across draft/pending/approved/rejected/approved). `--reset` truncates only the demo workspace's rows. Uses service-role client to bypass RLS. Prints generated passwords to stdout. Wired as `pnpm seed`.
- `tests/e2e/golden-path.spec.ts` — Playwright golden path on a 390x844 (iPhone 14) viewport: signup → invite PM → simulate accept (dev endpoint) → PM login → Owner creates project with budget → PM creates + submits PO → Owner approves → Company Dashboard `% used` updates within 5s. Uses `expect.toPass` polling to respect the 5s cadence.
- `src/app/api/test-only/last-invite/route.ts` — dev-only invite-token lookup used by the E2E spec. Disabled when `NODE_ENV=production` AND requires the `x-test-secret` header to match `TEST_INVITE_SECRET`.
- `.github/workflows/e2e.yml` — separate `e2e` job: Postgres service container, Supabase CLI for local stack + migrations, `pnpm seed`, `pnpm playwright install --with-deps chromium`, `pnpm test:e2e`. `continue-on-error: true` and gated by repo variable `E2E_ENABLED` (set to `"false"` to skip entirely).
- `vercel.json` + `README.md` — framework pinning and manual deploy steps. Not deploying automatically (credentials not configured).
- `playwright.config.ts` — mobile-first viewport, `TEST_INVITE_SECRET` plumbed into the dev server.

## Decisions
- **Dev-only invite endpoint gating**: two layers — `NODE_ENV !== 'production'` returns 404 (route disappears entirely from prod builds), and even in dev a missing/wrong `x-test-secret` header gets a 403. Path is `/api/test-only/last-invite` rather than `/api/_test/...` because Next.js treats leading-underscore folders as private and excludes them from routing — would silently 404.
- **E2E job strategy**: standalone GH Actions job with a Postgres service container plus Supabase CLI for the full local stack. Marked `continue-on-error: true` and additionally gated by repo var `E2E_ENABLED` so it doesn't block PRs while #3–#6 are in flight. Toggle documented in the workflow header.
- **Seed reset semantics**: `--reset` is workspace-scoped — deletes rows in `purchase_orders`, `request_slips`, `projects`, `invites`, `notifications`, etc. *only where `workspace_id` matches the demo workspace*. Memberships are preserved so the demo users still resolve into the workspace. Auth users themselves are never deleted; their passwords are rotated and re-printed each run for idempotency.

## Expected CI failures (until dependencies land)
- The `e2e` job will fail because the seed script and the spec exercise tables/UI from issues #3–#6 (workspaces, memberships, projects, purchase_orders, etc.). The job is `continue-on-error: true` so it won't block merge.
- The `build` job is green on this branch.

## Will turn CI green when these merge
- #3 (auth + workspaces + invites) — unblocks signup, invite flow, `/api/test-only/last-invite`, memberships table.
- #4 (projects + budget audit) — unblocks `projects` table, project create UI.
- #5 (POs + line items + state machine) — unblocks `purchase_orders`, `po_line_items`, PO create/submit/approve.
- #6 (dashboards + polling) — unblocks the Company Dashboard `% used` selector and the 5s refresh.

After all four merge, rebase this branch and the e2e suite should go green; flip `E2E_ENABLED` repo var to `"true"` (or remove `continue-on-error`) to enforce.

## Test plan
- [ ] After #3–#6 merge: rebase, run `pnpm seed` locally against `supabase start`, verify Owner/PM/projects/POs created.
- [ ] Run `pnpm test:e2e` locally on mobile viewport — confirm the golden path passes within ~30s.
- [ ] Confirm `/api/test-only/last-invite` 404s in a `NODE_ENV=production` build.
- [ ] Operator: `vercel link` + `vercel deploy --prebuilt` to a Vercel preview pointed at the Supabase staging project; manual smoke on a real phone over LTE.